### PR TITLE
chore: Build formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,26 @@ This'll launch it with the Electron build installed by `npm`.
 
 Additionally, if you really want to, you can build Viper with `npm run build` and it'll then build the Windows installer and AppImage, however the whole build process and everything related to it is still being worked on which is why we don't have official releases yet.
 
+## Install
+
+(this will be relevant once we start to publish releases)
+
+Downloads are available on the [releases page](https://github.com/0neGal/viper/releases). 
+
+Please note that some versions will update themselves automatically when a new release is available (just like Origin or Steam) and some will NOT, so choose it accordingly.
+
+Here is a list of all files:
+
+* Windows:
+  * `Viper Setup [x.y.z].exe` (recommanded) will install Viper on your computer; Viper will update itself automatically 
+  * `Viper [x.y.z].exe` is a stand-alone version of the software that does not need installation to be run; it will NOT update itself automatically
+* Linux:
+  * `.AppImage` benefits from auto-updating, unlike other Linux formats
+  * `.snap`
+  * `.tar.gz`
+  * `.deb`
+  * `.rpm`
+
 ## What can it do specifically?
 
 Currently Viper is capable of:

--- a/README.md
+++ b/README.md
@@ -28,21 +28,13 @@ Additionally, if you really want to, you can build Viper with `npm run build` an
 
 (this will be relevant once we start to publish releases)
 
-Downloads are available on the [releases page](https://github.com/0neGal/viper/releases). 
+Downloads are available on the [releases page](https://github.com/0neGal/viper/releases/latest). 
 
-Please note that some versions will update themselves automatically when a new release is available (just like Origin or Steam) and some will NOT, so choose it accordingly.
+Please note that some versions will (*[soon™](https://github.com/0neGal/viper/tree/auto-updates)*) update themselves automatically when a new release is available (just like Origin or Steam) and some will NOT, so choose it accordingly. Only the AppImage and Windows Setup/Installer can auto-update.
 
-Here is a list of all files:
+**Windows:** `Viper Setup [x.y.z].exe` (auto-updates, and is recommanded), `Viper [x.y.z].exe` (single executable, no fuss)
 
-* Windows:
-  * `Viper Setup [x.y.z].exe` (recommanded) will install Viper on your computer; Viper will update itself automatically 
-  * `Viper [x.y.z].exe` is a stand-alone version of the software that does not need installation to be run; it will NOT update itself automatically
-* Linux:
-  * `.AppImage` benefits from auto-updating, unlike other Linux formats
-  * `.snap`
-  * `.tar.gz`
-  * `.deb`
-  * `.rpm`
+**Linux:** `.AppImage` (auto-updates), `.deb`, `.rpm`, `.snap`, `.tar.gz`
 
 ## What can it do specifically?
 
@@ -50,8 +42,8 @@ Currently Viper is capable of:
 
  * Updating/Installing Northstar
  * Launching Vanilla and or Northstar
- * Manage Mods (Soon, see **mod-support** branch)
- * Auto-Update itself (Soon, see **auto-updater** branch)
+ * Manage Mods (Soon, see [**mod-support**](https://github.com/0neGal/viper/tree/mod-support) branch)
+ * Auto-Update itself (Soon, see [**auto-updater**](https://github.com/0neGal/viper/tree/auto-updates) branch)
  * Be pretty!
 
 Besides this I've been considering adding some easy to use VPK modding tools so everybody can have fun with VPK modding even if you don't know how to do it the traditional way. However that is not at the top of the todo list right now.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
 		"start": "npx electron src/index.js",
 		"debug": "npx electron src/index.js --debug",
 		"man": "npx marked-man docs/viper.1.md > docs/viper.1",
-		"build": "npx electron-builder --win nsis --linux appimage"
+		"build": "npx electron-builder --win nsis --win portable --linux appimage",
+		"build:windows": "npx electron-builder --win nsis --win portable",
 	},
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
 			"installerIcon": "icon.ico",
 			"uninstallerIcon": "icon.ico",
 			"installerHeaderIcon": "icon.ico"
+		},
+		"linux": {
+			"icon": "512x512.png"
 		}
 	},
 	"scripts": {
@@ -20,7 +23,8 @@
 		"debug": "npx electron src/index.js --debug",
 		"man": "npx marked-man docs/viper.1.md > docs/viper.1",
 		"build": "npx electron-builder --win nsis --win portable --linux appimage",
-		"build:windows": "npx electron-builder --win nsis --win portable"
+		"build:windows": "npx electron-builder --win nsis --win portable",
+		"build:linux": "npx electron-builder --linux appimage"
 	},
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"debug": "npx electron src/index.js --debug",
 		"man": "npx marked-man docs/viper.1.md > docs/viper.1",
 		"build": "npx electron-builder --win nsis --win portable --linux appimage",
-		"build:windows": "npx electron-builder --win nsis --win portable",
+		"build:windows": "npx electron-builder --win nsis --win portable"
 	},
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,15 @@
 			"installerHeaderIcon": "icon.ico"
 		},
 		"linux": {
-			"icon": "512x512.png"
+			"icon": "512x512.png",
+			"category": "Game",
+			"target": [
+				"AppImage",
+				"snap",
+				"deb",
+				"rpm",
+				"tar.gz"
+			]
 		}
 	},
 	"scripts": {
@@ -24,13 +32,13 @@
 		"man": "npx marked-man docs/viper.1.md > docs/viper.1",
 		"build": "npx electron-builder --win nsis --win portable --linux appimage",
 		"build:windows": "npx electron-builder --win nsis --win portable",
-		"build:linux": "npx electron-builder --linux appimage"
+		"build:linux": "npx electron-builder --linux"
 	},
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/0neGal/viper.git"
 	},
-	"author": "0neGal",
+	"author": "0neGal <mail@0negal.com>",
 	"license": "GPL-3.0-or-later",
 	"bugs": {
 		"url": "https://github.com/0neGal/viper/issues"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"start": "npx electron src/index.js",
 		"debug": "npx electron src/index.js --debug",
 		"man": "npx marked-man docs/viper.1.md > docs/viper.1",
-		"build": "npx electron-builder --win nsis --win portable --linux appimage",
+		"build": "npx electron-builder --win nsis --win portable --linux",
 		"build:windows": "npx electron-builder --win nsis --win portable",
 		"build:linux": "npx electron-builder --linux"
 	},


### PR DESCRIPTION
Build commands now build several Viper versions:
* Windows:
  * NSIS installer (with auto-update)
  * NSIS portable
* Linux:
  * `.AppImage` (with auto-update)
  * `.snap`
  * `.tar.gz`
  * `.deb`
  * `.rpm`

Closes #11.