### PR TITLE
fix: Rate limit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
 	"name": "viper",
-	"version": "0.9.0",
+	"version": "0.9.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "viper",
-			"version": "0.9.0",
+			"version": "0.9.1",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
+				"electron-fetch": "^1.7.4",
 				"electron-updater": "^4.6.1",
 				"follow-redirects": "^1.14.6",
 				"marked-man": "^0.7.0",
@@ -1455,6 +1456,17 @@
 				"node": ">= 10.0.0"
 			}
 		},
+		"node_modules/electron-fetch": {
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/electron-fetch/-/electron-fetch-1.7.4.tgz",
+			"integrity": "sha512-+fBLXEy4CJWQ5bz8dyaeSG1hD6JJ15kBZyj3eh24pIVrd3hLM47H/umffrdQfS6GZ0falF0g9JT9f3Rs6AVUhw==",
+			"dependencies": {
+				"encoding": "^0.1.13"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/electron-osx-sign": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.5.0.tgz",
@@ -1634,6 +1646,14 @@
 			"optional": true,
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/encoding": {
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+			"integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+			"dependencies": {
+				"iconv-lite": "^0.6.2"
 			}
 		},
 		"node_modules/end-of-stream": {
@@ -2085,7 +2105,6 @@
 			"version": "0.6.3",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
 			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-			"dev": true,
 			"dependencies": {
 				"safer-buffer": ">= 2.1.2 < 3.0.0"
 			},
@@ -4828,6 +4847,14 @@
 				}
 			}
 		},
+		"electron-fetch": {
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/electron-fetch/-/electron-fetch-1.7.4.tgz",
+			"integrity": "sha512-+fBLXEy4CJWQ5bz8dyaeSG1hD6JJ15kBZyj3eh24pIVrd3hLM47H/umffrdQfS6GZ0falF0g9JT9f3Rs6AVUhw==",
+			"requires": {
+				"encoding": "^0.1.13"
+			}
+		},
 		"electron-osx-sign": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.5.0.tgz",
@@ -4979,6 +5006,14 @@
 			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
 			"dev": true,
 			"optional": true
+		},
+		"encoding": {
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+			"integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+			"requires": {
+				"iconv-lite": "^0.6.2"
+			}
 		},
 		"end-of-stream": {
 			"version": "1.4.4",
@@ -5323,7 +5358,6 @@
 			"version": "0.6.3",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
 			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-			"dev": true,
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3.0.0"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
 			"version": "0.9.1",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
-				"electron-fetch": "^1.7.4",
 				"electron-updater": "^4.6.1",
 				"follow-redirects": "^1.14.6",
 				"marked-man": "^0.7.0",
@@ -1407,17 +1406,6 @@
 				"node": ">= 10.0.0"
 			}
 		},
-		"node_modules/electron-fetch": {
-			"version": "1.7.4",
-			"resolved": "https://registry.npmjs.org/electron-fetch/-/electron-fetch-1.7.4.tgz",
-			"integrity": "sha512-+fBLXEy4CJWQ5bz8dyaeSG1hD6JJ15kBZyj3eh24pIVrd3hLM47H/umffrdQfS6GZ0falF0g9JT9f3Rs6AVUhw==",
-			"dependencies": {
-				"encoding": "^0.1.13"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/electron-osx-sign": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.5.0.tgz",
@@ -1597,14 +1585,6 @@
 			"optional": true,
 			"engines": {
 				"node": ">= 0.8"
-			}
-		},
-		"node_modules/encoding": {
-			"version": "0.1.13",
-			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-			"integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-			"dependencies": {
-				"iconv-lite": "^0.6.2"
 			}
 		},
 		"node_modules/end-of-stream": {
@@ -1991,6 +1971,7 @@
 			"version": "0.6.3",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
 			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+			"dev": true,
 			"dependencies": {
 				"safer-buffer": ">= 2.1.2 < 3.0.0"
 			},
@@ -2806,7 +2787,8 @@
 		"node_modules/safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
 		},
 		"node_modules/sanitize-filename": {
 			"version": "1.6.3",
@@ -4556,14 +4538,6 @@
 				}
 			}
 		},
-		"electron-fetch": {
-			"version": "1.7.4",
-			"resolved": "https://registry.npmjs.org/electron-fetch/-/electron-fetch-1.7.4.tgz",
-			"integrity": "sha512-+fBLXEy4CJWQ5bz8dyaeSG1hD6JJ15kBZyj3eh24pIVrd3hLM47H/umffrdQfS6GZ0falF0g9JT9f3Rs6AVUhw==",
-			"requires": {
-				"encoding": "^0.1.13"
-			}
-		},
 		"electron-osx-sign": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.5.0.tgz",
@@ -4715,14 +4689,6 @@
 			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
 			"dev": true,
 			"optional": true
-		},
-		"encoding": {
-			"version": "0.1.13",
-			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-			"integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-			"requires": {
-				"iconv-lite": "^0.6.2"
-			}
 		},
 		"end-of-stream": {
 			"version": "1.4.4",
@@ -5019,6 +4985,7 @@
 			"version": "0.6.3",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
 			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+			"dev": true,
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3.0.0"
 			}
@@ -5642,7 +5609,8 @@
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
 		},
 		"sanitize-filename": {
 			"version": "1.6.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
 				"electron-updater": "^4.6.1",
 				"follow-redirects": "^1.14.6",
 				"marked-man": "^0.7.0",
-				"request": "^2.88.2",
 				"unzipper": "^0.10.11"
 			},
 			"devDependencies": {
@@ -302,6 +301,7 @@
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"dev": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -487,18 +487,12 @@
 				"@types/glob": "^7.1.1"
 			}
 		},
-		"node_modules/asn1": {
-			"version": "0.2.6",
-			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-			"integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-			"dependencies": {
-				"safer-buffer": "~2.1.0"
-			}
-		},
 		"node_modules/assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
 			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+			"dev": true,
+			"optional": true,
 			"engines": {
 				"node": ">=0.8"
 			}
@@ -531,7 +525,8 @@
 		"node_modules/asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"dev": true
 		},
 		"node_modules/at-least-node": {
 			"version": "1.0.0",
@@ -541,19 +536,6 @@
 			"engines": {
 				"node": ">= 4.0.0"
 			}
-		},
-		"node_modules/aws-sign2": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/aws4": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-			"integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
 		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
@@ -579,14 +561,6 @@
 					"url": "https://feross.org/support"
 				}
 			]
-		},
-		"node_modules/bcrypt-pbkdf": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-			"dependencies": {
-				"tweetnacl": "^0.14.3"
-			}
 		},
 		"node_modules/big-integer": {
 			"version": "1.6.51",
@@ -889,11 +863,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/caseless": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-		},
 		"node_modules/chainsaw": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
@@ -1013,6 +982,7 @@
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
 			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"dev": true,
 			"dependencies": {
 				"delayed-stream": "~1.0.0"
 			},
@@ -1124,17 +1094,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/dashdash": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-			"dependencies": {
-				"assert-plus": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
 		"node_modules/debug": {
 			"version": "4.3.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
@@ -1195,6 +1154,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"dev": true,
 			"engines": {
 				"node": ">=0.4.0"
 			}
@@ -1351,15 +1311,6 @@
 			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
 			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
 			"dev": true
-		},
-		"node_modules/ecc-jsbn": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-			"dependencies": {
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.1.0"
-			}
 		},
 		"node_modules/ejs": {
 			"version": "3.1.6",
@@ -1712,11 +1663,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/extend": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-		},
 		"node_modules/extract-zip": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
@@ -1751,19 +1697,23 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
 			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"dev": true,
 			"engines": [
 				"node >=0.6.0"
-			]
+			],
+			"optional": true
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"dev": true
 		},
 		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+			"dev": true
 		},
 		"node_modules/fd-slicer": {
 			"version": "1.1.0",
@@ -1800,27 +1750,6 @@
 				"debug": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/forever-agent": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/form-data": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-			"dependencies": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.6",
-				"mime-types": "^2.1.12"
-			},
-			"engines": {
-				"node": ">= 0.12"
 			}
 		},
 		"node_modules/fs-extra": {
@@ -1861,14 +1790,6 @@
 			},
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/getpass": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-			"dependencies": {
-				"assert-plus": "^1.0.0"
 			}
 		},
 		"node_modules/glob": {
@@ -2013,27 +1934,6 @@
 			"integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
 			"dev": true
 		},
-		"node_modules/har-schema": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/har-validator": {
-			"version": "5.1.5",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-			"integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-			"deprecated": "this library is no longer supported",
-			"dependencies": {
-				"ajv": "^6.12.3",
-				"har-schema": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2069,20 +1969,6 @@
 			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
 			"integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
 			"dev": true
-		},
-		"node_modules/http-signature": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-			"dependencies": {
-				"assert-plus": "^1.0.0",
-				"jsprim": "^1.2.2",
-				"sshpk": "^1.7.0"
-			},
-			"engines": {
-				"node": ">=0.8",
-				"npm": ">=1.3.7"
-			}
 		},
 		"node_modules/iconv-corefoundation": {
 			"version": "1.1.7",
@@ -2241,7 +2127,8 @@
 		"node_modules/is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"dev": true
 		},
 		"node_modules/is-yarn-global": {
 			"version": "0.3.0",
@@ -2271,11 +2158,6 @@
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
 			"dev": true
-		},
-		"node_modules/isstream": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
 		},
 		"node_modules/jake": {
 			"version": "10.8.2",
@@ -2377,31 +2259,24 @@
 				"js-yaml": "bin/js-yaml.js"
 			}
 		},
-		"node_modules/jsbn": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-		},
 		"node_modules/json-buffer": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
 			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
 			"dev": true
 		},
-		"node_modules/json-schema": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
-		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true
 		},
 		"node_modules/json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"dev": true,
+			"optional": true
 		},
 		"node_modules/json5": {
 			"version": "2.2.0",
@@ -2425,20 +2300,6 @@
 			"dev": true,
 			"optionalDependencies": {
 				"graceful-fs": "^4.1.6"
-			}
-		},
-		"node_modules/jsprim": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-			"integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-			"dependencies": {
-				"assert-plus": "1.0.0",
-				"extsprintf": "1.3.0",
-				"json-schema": "0.4.0",
-				"verror": "1.10.0"
-			},
-			"engines": {
-				"node": ">=0.6.0"
 			}
 		},
 		"node_modules/keyv": {
@@ -2575,6 +2436,7 @@
 			"version": "1.51.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
 			"integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
+			"dev": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -2583,6 +2445,7 @@
 			"version": "2.1.34",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
 			"integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
+			"dev": true,
 			"dependencies": {
 				"mime-db": "1.51.0"
 			},
@@ -2661,14 +2524,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/oauth-sign": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/object-keys": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -2734,11 +2589,6 @@
 			"integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
 			"dev": true
 		},
-		"node_modules/performance-now": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-		},
 		"node_modules/pify": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -2801,11 +2651,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"node_modules/psl": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
-		},
 		"node_modules/pump": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -2820,6 +2665,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"dev": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -2834,14 +2680,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/qs": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-			"engines": {
-				"node": ">=0.6"
 			}
 		},
 		"node_modules/rc": {
@@ -2911,37 +2749,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/request": {
-			"version": "2.88.2",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-			"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-			"deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-			"dependencies": {
-				"aws-sign2": "~0.7.0",
-				"aws4": "^1.8.0",
-				"caseless": "~0.12.0",
-				"combined-stream": "~1.0.6",
-				"extend": "~3.0.2",
-				"forever-agent": "~0.6.1",
-				"form-data": "~2.3.2",
-				"har-validator": "~5.1.3",
-				"http-signature": "~1.2.0",
-				"is-typedarray": "~1.0.0",
-				"isstream": "~0.1.2",
-				"json-stringify-safe": "~5.0.1",
-				"mime-types": "~2.1.19",
-				"oauth-sign": "~0.9.0",
-				"performance-now": "^2.1.0",
-				"qs": "~6.5.2",
-				"safe-buffer": "^5.1.2",
-				"tough-cookie": "~2.5.0",
-				"tunnel-agent": "^0.6.0",
-				"uuid": "^3.3.2"
-			},
-			"engines": {
-				"node": ">= 6"
 			}
 		},
 		"node_modules/require-directory": {
@@ -3143,30 +2950,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"node_modules/sshpk": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-			"dependencies": {
-				"asn1": "~0.2.3",
-				"assert-plus": "^1.0.0",
-				"bcrypt-pbkdf": "^1.0.0",
-				"dashdash": "^1.12.0",
-				"ecc-jsbn": "~0.1.1",
-				"getpass": "^0.1.1",
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.0.2",
-				"tweetnacl": "~0.14.0"
-			},
-			"bin": {
-				"sshpk-conv": "bin/sshpk-conv",
-				"sshpk-sign": "bin/sshpk-sign",
-				"sshpk-verify": "bin/sshpk-verify"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/stat-mode": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
@@ -3333,18 +3116,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/tough-cookie": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-			"dependencies": {
-				"psl": "^1.1.28",
-				"punycode": "^2.1.1"
-			},
-			"engines": {
-				"node": ">=0.8"
-			}
-		},
 		"node_modules/traverse": {
 			"version": "0.3.9",
 			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
@@ -3371,22 +3142,6 @@
 			"engines": {
 				"node": ">=0.6.11 <=0.7.0 || >=0.7.3"
 			}
-		},
-		"node_modules/tunnel-agent": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-			"dependencies": {
-				"safe-buffer": "^5.0.1"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/tweetnacl": {
-			"version": "0.14.5",
-			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
 		},
 		"node_modules/type-fest": {
 			"version": "0.13.1",
@@ -3533,6 +3288,7 @@
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"dev": true,
 			"dependencies": {
 				"punycode": "^2.1.0"
 			}
@@ -3560,22 +3316,15 @@
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
-		"node_modules/uuid": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-			"bin": {
-				"uuid": "bin/uuid"
-			}
-		},
 		"node_modules/verror": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"dev": true,
 			"engines": [
 				"node >=0.6.0"
 			],
+			"optional": true,
 			"dependencies": {
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
@@ -3585,7 +3334,9 @@
 		"node_modules/verror/node_modules/core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true,
+			"optional": true
 		},
 		"node_modules/which": {
 			"version": "2.0.2",
@@ -3952,6 +3703,7 @@
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -4096,18 +3848,12 @@
 				"minimatch": "^3.0.4"
 			}
 		},
-		"asn1": {
-			"version": "0.2.6",
-			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-			"integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-			"requires": {
-				"safer-buffer": "~2.1.0"
-			}
-		},
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+			"dev": true,
+			"optional": true
 		},
 		"astral-regex": {
 			"version": "2.0.0",
@@ -4131,23 +3877,14 @@
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"dev": true
 		},
 		"at-least-node": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
 			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
 			"dev": true
-		},
-		"aws-sign2": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-		},
-		"aws4": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-			"integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
 		},
 		"balanced-match": {
 			"version": "1.0.2",
@@ -4159,14 +3896,6 @@
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
 			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
 			"dev": true
-		},
-		"bcrypt-pbkdf": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-			"requires": {
-				"tweetnacl": "^0.14.3"
-			}
 		},
 		"big-integer": {
 			"version": "1.6.51",
@@ -4404,11 +4133,6 @@
 			"integrity": "sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==",
 			"dev": true
 		},
-		"caseless": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-		},
 		"chainsaw": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
@@ -4501,6 +4225,7 @@
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
 			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"dev": true,
 			"requires": {
 				"delayed-stream": "~1.0.0"
 			}
@@ -4591,14 +4316,6 @@
 			"integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
 			"dev": true
 		},
-		"dashdash": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-			"requires": {
-				"assert-plus": "^1.0.0"
-			}
-		},
 		"debug": {
 			"version": "4.3.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
@@ -4641,7 +4358,8 @@
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"dev": true
 		},
 		"detect-node": {
 			"version": "2.1.0",
@@ -4768,15 +4486,6 @@
 			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
 			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
 			"dev": true
-		},
-		"ecc-jsbn": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-			"requires": {
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.1.0"
-			}
 		},
 		"ejs": {
 			"version": "3.1.6",
@@ -5056,11 +4765,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"extend": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-		},
 		"extract-zip": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
@@ -5093,17 +4797,21 @@
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"dev": true,
+			"optional": true
 		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"dev": true
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+			"dev": true
 		},
 		"fd-slicer": {
 			"version": "1.1.0",
@@ -5127,21 +4835,6 @@
 			"version": "1.14.6",
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.6.tgz",
 			"integrity": "sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A=="
-		},
-		"forever-agent": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-		},
-		"form-data": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-			"requires": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.6",
-				"mime-types": "^2.1.12"
-			}
 		},
 		"fs-extra": {
 			"version": "8.1.0",
@@ -5172,14 +4865,6 @@
 			"dev": true,
 			"requires": {
 				"pump": "^3.0.0"
-			}
-		},
-		"getpass": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-			"requires": {
-				"assert-plus": "^1.0.0"
 			}
 		},
 		"glob": {
@@ -5292,20 +4977,6 @@
 			"integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
 			"dev": true
 		},
-		"har-schema": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-		},
-		"har-validator": {
-			"version": "5.1.5",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-			"integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-			"requires": {
-				"ajv": "^6.12.3",
-				"har-schema": "^2.0.0"
-			}
-		},
 		"has-flag": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -5332,16 +5003,6 @@
 			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
 			"integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
 			"dev": true
-		},
-		"http-signature": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-			"requires": {
-				"assert-plus": "^1.0.0",
-				"jsprim": "^1.2.2",
-				"sshpk": "^1.7.0"
-			}
 		},
 		"iconv-corefoundation": {
 			"version": "1.1.7",
@@ -5447,7 +5108,8 @@
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"dev": true
 		},
 		"is-yarn-global": {
 			"version": "0.3.0",
@@ -5471,11 +5133,6 @@
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
 			"dev": true
-		},
-		"isstream": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
 		},
 		"jake": {
 			"version": "10.8.2",
@@ -5555,31 +5212,24 @@
 				"argparse": "^2.0.1"
 			}
 		},
-		"jsbn": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-		},
 		"json-buffer": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
 			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
 			"dev": true
 		},
-		"json-schema": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
-		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true
 		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"dev": true,
+			"optional": true
 		},
 		"json5": {
 			"version": "2.2.0",
@@ -5597,17 +5247,6 @@
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.6"
-			}
-		},
-		"jsprim": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-			"integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-			"requires": {
-				"assert-plus": "1.0.0",
-				"extsprintf": "1.3.0",
-				"json-schema": "0.4.0",
-				"verror": "1.10.0"
 			}
 		},
 		"keyv": {
@@ -5708,12 +5347,14 @@
 		"mime-db": {
 			"version": "1.51.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
-			"integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g=="
+			"integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
+			"dev": true
 		},
 		"mime-types": {
 			"version": "2.1.34",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
 			"integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
+			"dev": true,
 			"requires": {
 				"mime-db": "1.51.0"
 			}
@@ -5774,11 +5415,6 @@
 				"pify": "^3.0.0"
 			}
 		},
-		"oauth-sign": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
-		},
 		"object-keys": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -5829,11 +5465,6 @@
 			"integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
 			"dev": true
 		},
-		"performance-now": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-		},
 		"pify": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -5883,11 +5514,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"psl": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
-		},
 		"pump": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -5901,7 +5527,8 @@
 		"punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"dev": true
 		},
 		"pupa": {
 			"version": "2.1.1",
@@ -5911,11 +5538,6 @@
 			"requires": {
 				"escape-goat": "^2.0.0"
 			}
-		},
-		"qs": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
 		},
 		"rc": {
 			"version": "1.2.8",
@@ -5972,33 +5594,6 @@
 			"dev": true,
 			"requires": {
 				"rc": "^1.2.8"
-			}
-		},
-		"request": {
-			"version": "2.88.2",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-			"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-			"requires": {
-				"aws-sign2": "~0.7.0",
-				"aws4": "^1.8.0",
-				"caseless": "~0.12.0",
-				"combined-stream": "~1.0.6",
-				"extend": "~3.0.2",
-				"forever-agent": "~0.6.1",
-				"form-data": "~2.3.2",
-				"har-validator": "~5.1.3",
-				"http-signature": "~1.2.0",
-				"is-typedarray": "~1.0.0",
-				"isstream": "~0.1.2",
-				"json-stringify-safe": "~5.0.1",
-				"mime-types": "~2.1.19",
-				"oauth-sign": "~0.9.0",
-				"performance-now": "^2.1.0",
-				"qs": "~6.5.2",
-				"safe-buffer": "^5.1.2",
-				"tough-cookie": "~2.5.0",
-				"tunnel-agent": "^0.6.0",
-				"uuid": "^3.3.2"
 			}
 		},
 		"require-directory": {
@@ -6163,22 +5758,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"sshpk": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-			"requires": {
-				"asn1": "~0.2.3",
-				"assert-plus": "^1.0.0",
-				"bcrypt-pbkdf": "^1.0.0",
-				"dashdash": "^1.12.0",
-				"ecc-jsbn": "~0.1.1",
-				"getpass": "^0.1.1",
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.0.2",
-				"tweetnacl": "~0.14.0"
-			}
-		},
 		"stat-mode": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
@@ -6311,15 +5890,6 @@
 			"integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
 			"dev": true
 		},
-		"tough-cookie": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-			"requires": {
-				"psl": "^1.1.28",
-				"punycode": "^2.1.1"
-			}
-		},
 		"traverse": {
 			"version": "0.3.9",
 			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
@@ -6340,19 +5910,6 @@
 			"integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
 			"dev": true,
 			"optional": true
-		},
-		"tunnel-agent": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-			"requires": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"tweetnacl": {
-			"version": "0.14.5",
-			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
 		},
 		"type-fest": {
 			"version": "0.13.1",
@@ -6473,6 +6030,7 @@
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
 			}
@@ -6497,15 +6055,12 @@
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
-		"uuid": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-		},
 		"verror": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"dev": true,
+			"optional": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
@@ -6515,7 +6070,9 @@
 				"core-util-is": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+					"dev": true,
+					"optional": true
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
 		"electron-updater": "^4.6.1",
 		"follow-redirects": "^1.14.6",
 		"marked-man": "^0.7.0",
-		"request": "^2.88.2",
 		"unzipper": "^0.10.11"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,11 +30,9 @@
 		"start": "npx electron src/index.js",
 		"debug": "npx electron src/index.js --debug",
 		"man": "npx marked-man docs/viper.1.md > docs/viper.1",
-
 		"build": "npx electron-builder --win nsis --win portable --linux",
 		"build:windows": "npx electron-builder --win nsis --win portable",
 		"build:linux": "npx electron-builder --linux",
-
 		"publish": "npx electron-builder --win nsis --win portable --linux -p always",
 		"publish:windows": "npx electron-builder --win nsis --win portable -p always",
 		"publish:linux": "npx electron-builder --linux -p always"
@@ -50,6 +48,7 @@
 	},
 	"homepage": "https://github.com/0neGal/viper#readme",
 	"dependencies": {
+		"electron-fetch": "^1.7.4",
 		"electron-updater": "^4.6.1",
 		"follow-redirects": "^1.14.6",
 		"marked-man": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -30,9 +30,11 @@
 		"start": "npx electron src/index.js",
 		"debug": "npx electron src/index.js --debug",
 		"man": "npx marked-man docs/viper.1.md > docs/viper.1",
+
 		"build": "npx electron-builder --win nsis --win portable --linux",
 		"build:windows": "npx electron-builder --win nsis --win portable",
 		"build:linux": "npx electron-builder --linux",
+
 		"publish": "npx electron-builder --win nsis --win portable --linux -p always",
 		"publish:windows": "npx electron-builder --win nsis --win portable -p always",
 		"publish:linux": "npx electron-builder --linux -p always"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
 	},
 	"homepage": "https://github.com/0neGal/viper#readme",
 	"dependencies": {
-		"electron-fetch": "^1.7.4",
 		"electron-updater": "^4.6.1",
 		"follow-redirects": "^1.14.6",
 		"marked-man": "^0.7.0",

--- a/src/requests.js
+++ b/src/requests.js
@@ -39,8 +39,10 @@ async function getLatestNsVersion() {
     }
 }
 
+// should always be called after getLatestNsVersion
 function getLatestNsVersionLink() {
-    return '';
+    const cache = _getRequestsCache();
+    return cache['nsLatest']['body'].assets[0].browser_download_url;
 }
 
 

--- a/src/requests.js
+++ b/src/requests.js
@@ -5,8 +5,8 @@ const { https } = require("follow-redirects");
 
 
 // all requests results are stored in this file
-const cachePath = path.join(app.getPath("appData"), 'requests.json');
-const NORTHSTAR_LATEST_RELEASE_KEY = 'nsLatestRelease';
+const cachePath = path.join(app.getPath("appData"), "requests.json");
+const NORTHSTAR_LATEST_RELEASE_KEY = "nsLatestRelease";
 
 
 function _saveCache(data) {
@@ -22,56 +22,52 @@ function _getRequestsCache() {
     }
 }
 
-/**
- * Returns latest Northstar version available from GitHub releases.
- * If there's no cache result for this request, or if cache exists but is old, refreshes
- * cache with new data.
- */
+// Returns latest Northstar version available from GitHub releases. If
+// there's no cache result for this request, or if cache exists but is
+// old, refreshes cache with new data.
 async function getLatestNsVersion() {
     return new Promise((resolve, reject) => {
         let cache = _getRequestsCache();
     
-        if (cache[NORTHSTAR_LATEST_RELEASE_KEY] && (Date.now() - cache[NORTHSTAR_LATEST_RELEASE_KEY]['time']) < 5 * 60 * 1000) {
+        if (cache[NORTHSTAR_LATEST_RELEASE_KEY] && (Date.now() - cache[NORTHSTAR_LATEST_RELEASE_KEY]["time"]) < 5 * 60 * 1000) {
             console.log(`returning ${NORTHSTAR_LATEST_RELEASE_KEY} data from cache`);
-            resolve( cache[NORTHSTAR_LATEST_RELEASE_KEY]['body']['tag_name'] );
+            resolve( cache[NORTHSTAR_LATEST_RELEASE_KEY]["body"]["tag_name"] );
         } else {
             https.get({
-                host: 'api.github.com',
+                host: "api.github.com",
                 port: 443,
-                path: '/repos/R2Northstar/Northstar/releases/latest',
-                method: 'GET',
-                headers: { 'User-Agent': "viper" }
+                path: "/repos/R2Northstar/Northstar/releases/latest",
+                method: "GET",
+                headers: { "User-Agent": "viper" }
             }, 
             
             response => {
-                response.setEncoding('utf8');
-                let responseData = '';
+                response.setEncoding("utf8");
+                let responseData = "";
 
-                response.on('data', data => {
+                response.on("data", data => {
                     responseData += data;
                 });
 
-                response.on('end', _ => {                    
+                response.on("end", _ => {                    
                     cache[NORTHSTAR_LATEST_RELEASE_KEY] = {
-                        'time': Date.now(),
-                        'body': JSON.parse(responseData)
+                        "time": Date.now(),
+                        "body": JSON.parse(responseData)
                     };
                     _saveCache(cache);
-                    resolve( cache[NORTHSTAR_LATEST_RELEASE_KEY]['body']['tag_name'] );
+                    resolve( cache[NORTHSTAR_LATEST_RELEASE_KEY]["body"]["tag_name"] );
                 });
             });
         }
     });
 }
 
-/**
- * Returns the download link to latest Northstar version.
- * Should always be called after getLatestNsVersion, as it refreshes 
- * cache data (if needed).
- */
+// Returns the download link to latest Northstar version. Should always
+// be called after getLatestNsVersion, as it refreshes cache data (if
+// needed).
 function getLatestNsVersionLink() {
     const cache = _getRequestsCache();
-    return cache[NORTHSTAR_LATEST_RELEASE_KEY]['body'].assets[0].browser_download_url;
+    return cache[NORTHSTAR_LATEST_RELEASE_KEY]["body"].assets[0].browser_download_url;
 }
 
 

--- a/src/requests.js
+++ b/src/requests.js
@@ -6,6 +6,7 @@ const fetch = require('electron-fetch').default
 
 // all requests results are stored in this file
 const cachePath = path.join(app.getPath("appData"), 'requests.json');
+const NORTHSTAR_LATEST_RELEASE_KEY = 'nsLatestRelease';
 
 
 function _saveCache(data) {
@@ -29,18 +30,18 @@ function _getRequestsCache() {
 async function getLatestNsVersion() {
     let cache = _getRequestsCache();
     
-    if (cache['nsLatest'] && (Date.now() - cache['nsLatest']['time']) < 5 * 60 * 1000) {
-        console.log('returning nsLatest data from cache')
-        return cache['nsLatest']['body']['tag_name'];
+    if (cache[NORTHSTAR_LATEST_RELEASE_KEY] && (Date.now() - cache[NORTHSTAR_LATEST_RELEASE_KEY]['time']) < 5 * 60 * 1000) {
+        console.log(`returning ${NORTHSTAR_LATEST_RELEASE_KEY} data from cache`);
+        return cache[NORTHSTAR_LATEST_RELEASE_KEY]['body']['tag_name'];
     } else {
         const response = await fetch("https://api.github.com/repos/R2Northstar/Northstar/releases/latest");
 
-        cache['nsLatest'] = {
+        cache[NORTHSTAR_LATEST_RELEASE_KEY] = {
             'time': Date.now(),
             'body': await response.json()
         };
         _saveCache(cache);
-        return cache['nsLatest']['body']['tag_name'];
+        return cache[NORTHSTAR_LATEST_RELEASE_KEY]['body']['tag_name'];
     }
 }
 
@@ -51,7 +52,7 @@ async function getLatestNsVersion() {
  */
 function getLatestNsVersionLink() {
     const cache = _getRequestsCache();
-    return cache['nsLatest']['body'].assets[0].browser_download_url;
+    return cache[NORTHSTAR_LATEST_RELEASE_KEY]['body'].assets[0].browser_download_url;
 }
 
 

--- a/src/requests.js
+++ b/src/requests.js
@@ -21,6 +21,11 @@ function _getRequestsCache() {
     }
 }
 
+/**
+ * Returns latest Northstar version available from GitHub releases.
+ * If there's no cache result for this request, or if cache exists but is old, refreshes
+ * cache with new data.
+ */
 async function getLatestNsVersion() {
     let cache = _getRequestsCache();
     
@@ -39,7 +44,11 @@ async function getLatestNsVersion() {
     }
 }
 
-// should always be called after getLatestNsVersion
+/**
+ * Returns the download link to latest Northstar version.
+ * Should always be called after getLatestNsVersion, as it refreshes 
+ * cache data (if needed).
+ */
 function getLatestNsVersionLink() {
     const cache = _getRequestsCache();
     return cache['nsLatest']['body'].assets[0].browser_download_url;

--- a/src/requests.js
+++ b/src/requests.js
@@ -1,0 +1,50 @@
+const { app } = require("electron");
+const path = require("path");
+const fs = require("fs");
+const fetch = require('electron-fetch').default
+
+
+// all requests results are stored in this file
+const cachePath = path.join(app.getPath("appData"), 'requests.json');
+
+
+function _saveCache(data) {
+    fs.writeFileSync(cachePath, JSON.stringify(data));
+}
+
+function _getRequestsCache() {
+    if (fs.existsSync(cachePath)) {
+        return JSON.parse(fs.readFileSync(cachePath, "utf8"));
+    } else {
+        fs.writeFileSync(cachePath, "{}");
+        return {};
+    }
+}
+
+async function getLatestNsVersion() {
+    let cache = _getRequestsCache();
+    
+    if (cache['nsLatest'] && (Date.now() - cache['nsLatest']['time']) > 5 * 60 * 1000) {
+        console.log('returning nsLatest data from cache')
+        return cache['nsLatest']['body']['tag_name'];
+    } else {
+        const response = await fetch("https://api.github.com/repos/R2Northstar/Northstar/releases/latest");
+
+        cache['nsLatest'] = {
+            'time': Date.now(),
+            'body': await response.json()
+        };
+        _saveCache(cache);
+        return cache['nsLatest']['body']['tag_name'];
+    }
+}
+
+function getLatestNsVersionLink() {
+    return '';
+}
+
+
+module.exports = {
+    getLatestNsVersion, 
+    getLatestNsVersionLink
+};

--- a/src/requests.js
+++ b/src/requests.js
@@ -5,7 +5,7 @@ const { https } = require("follow-redirects");
 
 
 // all requests results are stored in this file
-const cachePath = path.join(app.getPath("appData"), "requests.json");
+const cachePath = path.join(app.getPath("cache"), "requests.json");
 const NORTHSTAR_LATEST_RELEASE_KEY = "nsLatestRelease";
 
 

--- a/src/requests.js
+++ b/src/requests.js
@@ -24,7 +24,7 @@ function _getRequestsCache() {
 async function getLatestNsVersion() {
     let cache = _getRequestsCache();
     
-    if (cache['nsLatest'] && (Date.now() - cache['nsLatest']['time']) > 5 * 60 * 1000) {
+    if (cache['nsLatest'] && (Date.now() - cache['nsLatest']['time']) < 5 * 60 * 1000) {
         console.log('returning nsLatest data from cache')
         return cache['nsLatest']['body']['tag_name'];
     } else {

--- a/src/requests.js
+++ b/src/requests.js
@@ -1,7 +1,6 @@
 const { app } = require("electron");
 const path = require("path");
 const fs = require("fs");
-const fetch = require('electron-fetch').default
 const { https } = require("follow-redirects");
 
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -93,12 +93,12 @@ async function update() {
 	} else {
 		if (version != "unknown") {
 			console.log(lang("cli.update.current"), version);
-		}; console.log(lang("cli.update.downloading") + ":", tag);
+		}; console.log(lang("cli.update.downloading") + ":", latestAvailableVersion);
 
 		winLog(lang("gui.update.downloading"));
 	}
 
-	https.get(body.assets[0].browser_download_url, (res) => {
+	https.get(requests.getLatestNsVersionLink(), (res) => {
 		let stream = fs.createWriteStream(settings.zip);
 		res.pipe(stream);
 
@@ -114,7 +114,7 @@ async function update() {
 			console.log(lang("cli.update.downloaddone"));
 			fs.createReadStream(settings.zip).pipe(unzip.Extract({path: settings.gamepath}))
 			.on("finish", () => {
-				fs.writeFileSync(path.join(settings.gamepath, "ns_version.txt"), tag);
+				fs.writeFileSync(path.join(settings.gamepath, "ns_version.txt"), latestAvailableVersion);
 				ipcMain.emit("getversion");
 
 				for (let i = 0; i < settings.excludes.length; i++) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -10,7 +10,6 @@ const lang = require("./lang");
 const requests = require('./requests');
 
 const unzip = require("unzipper");
-const request = require("request");
 const exec = require("child_process").spawn;
 const { https } = require("follow-redirects");
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,6 +7,7 @@ const events = new Emitter();
 
 const cli = require("./cli");
 const lang = require("./lang");
+const requests = require('./requests');
 
 const unzip = require("unzipper");
 const request = require("request");
@@ -69,7 +70,7 @@ function getNSVersion() {
 	}
 }
 
-function update() {
+async function update() {
 	for (let i = 0; i < settings.excludes.length; i++) {
 		let exclude = path.join(settings.gamepath + "/" + settings.excludes[i]);
 		if (fs.existsSync(exclude)) {
@@ -81,59 +82,53 @@ function update() {
 	console.log(lang("cli.update.checking"));
 	var version = getNSVersion();
 
-	request({
-		json: true,
-		headers: {"User-Agent": "Viper"},
-		url: "https://api.github.com/repos/R2Northstar/Northstar/releases/latest",
-	}, (error, response, body) => {
-		var tag = body["tag_name"];
+	const latestAvailableVersion = await requests.getLatestNsVersion();
 
-		if (version === tag) {
-			ipcMain.emit("ns-updated");
-			console.log(lang("cli.update.uptodate"), version);
+	if (version === latestAvailableVersion) {
+		ipcMain.emit("ns-updated");
+		console.log(lang("cli.update.uptodate"), version);
 
-			winLog(lang("gui.update.uptodate"));
-			return;
-		} else {
-			if (version != "unknown") {
-				console.log(lang("cli.update.current"), version);
-			}; console.log(lang("cli.update.downloading") + ":", tag);
+		winLog(lang("gui.update.uptodate"));
+		return;
+	} else {
+		if (version != "unknown") {
+			console.log(lang("cli.update.current"), version);
+		}; console.log(lang("cli.update.downloading") + ":", tag);
 
-			winLog(lang("gui.update.downloading"));
-		}
+		winLog(lang("gui.update.downloading"));
+	}
 
-		https.get(body.assets[0].browser_download_url, (res) => {
-			let stream = fs.createWriteStream(settings.zip);
-			res.pipe(stream);
+	https.get(body.assets[0].browser_download_url, (res) => {
+		let stream = fs.createWriteStream(settings.zip);
+		res.pipe(stream);
 
-			let received = 0;
-			res.on("data", (chunk) => {
-				received += chunk.length;
-				winLog(lang("gui.update.downloading") + " " + (received / 1024 / 1024).toFixed(1) + "mb");
-			})
+		let received = 0;
+		res.on("data", (chunk) => {
+			received += chunk.length;
+			winLog(lang("gui.update.downloading") + " " + (received / 1024 / 1024).toFixed(1) + "mb");
+		})
 
-			stream.on("finish", () => {
-				stream.close();
-				winLog(lang("gui.update.extracting"));
-				console.log(lang("cli.update.downloaddone"));
-				fs.createReadStream(settings.zip).pipe(unzip.Extract({path: settings.gamepath}))
-				.on("finish", () => {
-					fs.writeFileSync(path.join(settings.gamepath, "ns_version.txt"), tag);
-					ipcMain.emit("getversion");
+		stream.on("finish", () => {
+			stream.close();
+			winLog(lang("gui.update.extracting"));
+			console.log(lang("cli.update.downloaddone"));
+			fs.createReadStream(settings.zip).pipe(unzip.Extract({path: settings.gamepath}))
+			.on("finish", () => {
+				fs.writeFileSync(path.join(settings.gamepath, "ns_version.txt"), tag);
+				ipcMain.emit("getversion");
 
-					for (let i = 0; i < settings.excludes.length; i++) {
-						let exclude = path.join(settings.gamepath + "/" + settings.excludes[i]);
-						if (fs.existsSync(exclude + ".excluded")) {
-							fs.renameSync(exclude + ".excluded", exclude)
-						}
+				for (let i = 0; i < settings.excludes.length; i++) {
+					let exclude = path.join(settings.gamepath + "/" + settings.excludes[i]);
+					if (fs.existsSync(exclude + ".excluded")) {
+						fs.renameSync(exclude + ".excluded", exclude)
 					}
+				}
 
-					ipcMain.emit("ns-updated");
-					winLog(lang("gui.update.finished"));
-					console.log(lang("cli.update.finished"));
-					cli.exit();
-				});
-			})
+				ipcMain.emit("ns-updated");
+				winLog(lang("gui.update.finished"));
+				console.log(lang("cli.update.finished"));
+				cli.exit();
+			});
 		})
 	})
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,7 +7,7 @@ const events = new Emitter();
 
 const cli = require("./cli");
 const lang = require("./lang");
-const requests = require('./requests');
+const requests = require("./requests");
 
 const unzip = require("unzipper");
 const exec = require("child_process").spawn;


### PR DESCRIPTION
When clicking "update" button, request result is stored on a file, which is used as cache if "update" button is pressed within next 5 minutes, preventing GitHub rate limit to take effect.
Closes #23.

This also removes deprecated `request` dependency.

---

If #26 is merged, both Northstar and Viper HTTP requests to get release notes should be implemented in the new `requests` module, to benefit from caching.