### PR TITLE
fix: Game path check

### DIFF
--- a/src/app/main.js
+++ b/src/app/main.js
@@ -83,6 +83,7 @@ ipcRenderer.on("nopathselected", () => {
 	alert(lang("gui.gamepath.must"));
 	exit();
 });
+
 ipcRenderer.on("wrongpath", () => {
 	alert(lang("gui.gamepath.wrong"));
 	setpath(false);

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -84,7 +84,7 @@ ipcRenderer.on("nopathselected", () => {
 	exit();
 });
 ipcRenderer.on("wrongpath", () => {
-	alert("wrong path bro");
+	alert(lang("gui.gamepath.wrong"));
 });
 
 setlang();

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -85,6 +85,7 @@ ipcRenderer.on("nopathselected", () => {
 });
 ipcRenderer.on("wrongpath", () => {
 	alert(lang("gui.gamepath.wrong"));
+	setpath(false);
 });
 
 setlang();

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -83,6 +83,9 @@ ipcRenderer.on("nopathselected", () => {
 	alert(lang("gui.gamepath.must"));
 	exit();
 });
+ipcRenderer.on("wrongpath", () => {
+	alert("wrong path bro");
+});
 
 setlang();
 setInterval(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -72,8 +72,9 @@ ipcMain.on("newpath", (event, newpath) => {
 			win.show();
 		}
 	}
+}); ipcMain.on("wrongpath", (event) => {
+	win.webContents.send("wrongpath");
 });
-ipcMain.on("wrongpath", _ => win.webContents.send("wrongpath"));
 
 ipcMain.on("getversion", () => {
 	win.webContents.send("version", {

--- a/src/index.js
+++ b/src/index.js
@@ -73,6 +73,7 @@ ipcMain.on("newpath", (event, newpath) => {
 		}
 	}
 });
+ipcMain.on("wrongpath", _ => win.webContents.send("wrongpath"));
 
 ipcMain.on("getversion", () => {
 	win.webContents.send("version", {

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -37,6 +37,7 @@
 
 	"gui.selectpath": "Please select the path!",
 	"gui.gamepath.must": "The game path must be set to start Viper.",
+	"gui.gamepath.wrong": "This folder is not a valid game path.",
 
 
 	"general.launching": "Launching",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -37,6 +37,7 @@
 
 	"gui.selectpath": "Veuillez sélectionner le dossier où se trouve le client Titanfall 2.",
 	"gui.gamepath.must": "Vous devez sélectionner le chemin du dossier du jeu Titanfall 2 pour pouvoir lancer Viper.",
+	"gui.gamepath.wrong": "Ce dossier ne contient pas le jeu Titanfall 2, et n'est donc pas valide.",
 
 
 	"general.launching": "Lancement",

--- a/src/utils.js
+++ b/src/utils.js
@@ -42,10 +42,11 @@ function setpath(win) {
 				ipcMain.emit("newpath", null, false);
 				return;
 			}
-			if (!checkGamePath(res.filePaths[0])) {
+			if (! fs.existsSync(path.join(res.filePaths[0], "Titanfall2.exe"))) {
 				ipcMain.emit("wrongpath");
 				return;
 			}
+
 			settings.gamepath = res.filePaths[0];
 			settings.zip = path.join(settings.gamepath + "/northstar.zip");
 			saveSettings();
@@ -56,13 +57,6 @@ function setpath(win) {
 
 	fs.writeFileSync(app.getPath("appData") + "/viper.json", JSON.stringify(settings));
 	cli.exit();
-}
-
-/**
- * A game path is valid if it contains "Titanfall2.exe" file.
- */
-function checkGamePath(gamepath) {
-	return fs.existsSync(path.join(gamepath, "Titanfall2.exe"));
 }
 
 function saveSettings() {

--- a/src/utils.js
+++ b/src/utils.js
@@ -42,6 +42,10 @@ function setpath(win) {
 				ipcMain.emit("newpath", null, false);
 				return;
 			}
+			if (!checkGamePath(res.filePaths[0])) {
+				ipcMain.emit("wrongpath");
+				return;
+			}
 			settings.gamepath = res.filePaths[0];
 			settings.zip = path.join(settings.gamepath + "/northstar.zip");
 			saveSettings();
@@ -52,6 +56,10 @@ function setpath(win) {
 
 	fs.writeFileSync(app.getPath("appData") + "/viper.json", JSON.stringify(settings));
 	cli.exit();
+}
+
+function checkGamePath(gamepath) {
+	return false;
 }
 
 function saveSettings() {

--- a/src/utils.js
+++ b/src/utils.js
@@ -58,8 +58,11 @@ function setpath(win) {
 	cli.exit();
 }
 
+/**
+ * A game path is valid if it contains "Titanfall2.exe" file.
+ */
 function checkGamePath(gamepath) {
-	return false;
+	return fs.existsSync(path.join(gamepath, "Titanfall2.exe"));
 }
 
 function saveSettings() {


### PR DESCRIPTION
If prompted game path does not contain `Titanfall2.exe`, an error message will be displayed.
While game path is not correct, user will be prompted to enter it.