### PR TITLE
fix: Excluded files

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -202,6 +202,19 @@ function getTF2Version() {
 	}
 }
 
+
+// Renames excluded files to their original name
+function restoreExcludedFiles() {
+	for (let i = 0; i < settings.excludes.length; i++) {
+		let exclude = path.join(settings.gamepath + "/" + settings.excludes[i]);
+		if (fs.existsSync(exclude + ".excluded")) {
+			fs.renameSync(exclude + ".excluded", exclude)
+		}
+	}
+}
+// At start, restore excluded files who might have been created by an incomplete update process.
+restoreExcludedFiles();
+
 // Installs/Updates Northstar
 //
 // If Northstar is already installed it'll be an update, otherwise it'll
@@ -263,16 +276,10 @@ async function update() {
 			// installing Northstar.
 			fs.createReadStream(settings.zip).pipe(unzip.Extract({path: settings.gamepath}))
 			.on("finish", () => {
-					fs.writeFileSync(path.join(settings.gamepath, "ns_version.txt"), latestAvailableVersion);
-					ipcMain.emit("getversion");
+				fs.writeFileSync(path.join(settings.gamepath, "ns_version.txt"), latestAvailableVersion);
+				ipcMain.emit("getversion");
 
-				// Renames excluded files to their original name
-				for (let i = 0; i < settings.excludes.length; i++) {
-					let exclude = path.join(settings.gamepath + "/" + settings.excludes[i]);
-					if (fs.existsSync(exclude + ".excluded")) {
-						fs.renameSync(exclude + ".excluded", exclude)
-					}
-				}
+				restoreExcludedFiles();
 
 				ipcMain.emit("guigetmods");
 				ipcMain.emit("ns-update-event", "cli.update.uptodate.short");

--- a/src/utils.js
+++ b/src/utils.js
@@ -212,14 +212,6 @@ function getTF2Version() {
 // <file>.excluded, then rename them back after the extraction. The
 // unzip module does not support excluding files directly.
 async function update() {
-	// Renames excluded files to <file>.excluded
-	for (let i = 0; i < settings.excludes.length; i++) {
-		let exclude = path.join(settings.gamepath + "/" + settings.excludes[i]);
-		if (fs.existsSync(exclude)) {
-			fs.renameSync(exclude, exclude + ".excluded")
-		}
-	}
-
 	ipcMain.emit("ns-update-event", "cli.update.checking");
 	console.log(lang("cli.update.checking"));
 	var version = getNSVersion();
@@ -239,6 +231,14 @@ async function update() {
 		}; 
 		console.log(lang("cli.update.downloading") + ":", latestAvailableVersion);
 		ipcMain.emit("ns-update-event", "cli.update.downloading");
+	}
+
+	// Renames excluded files to <file>.excluded
+	for (let i = 0; i < settings.excludes.length; i++) {
+		let exclude = path.join(settings.gamepath + "/" + settings.excludes[i]);
+		if (fs.existsSync(exclude)) {
+			fs.renameSync(exclude, exclude + ".excluded")
+		}
 	}
 
 	// Start the download of the zip


### PR DESCRIPTION
Excluded files were being renamed (+ ".excluded") at update process start, but would not be renamed back to their normal names if no update is available.

Also, if there are excluded files, Viper renames them (removes ".excluded") at start.

Closes #61.