### PR TITLE
refactor: i18n

### DIFF
--- a/src/lang.js
+++ b/src/lang.js
@@ -1,35 +1,34 @@
 const fs = require("fs");
 
-var lang = "en"; // Default language
+const enLang = JSON.parse(fs.readFileSync(__dirname + `/lang/en.json`, "utf8"));
+let lang = "en";
+var langObj = {};
 
-// Loads fallback/default language strings
-var langDef = JSON.parse(fs.readFileSync(__dirname + `/lang/en.json`, "utf8"));
 
-// If settins are set it'll try to set the language to that instead of
-// the default, however if it can't find it, it'll still fallback to the
-// default language. This might happen as the default language is
-// retrieved from the renderer's navigator.language, which may have
-// languages we don't support yet.
-if (fs.existsSync("viper.json")) {
-	lang = JSON.parse(fs.readFileSync("viper.json", "utf8")).lang;
-	if (! lang) {lang = "en"} // Uses fallback, if language isn't set
-	if (! fs.existsSync(__dirname + `/lang/${lang}.json`)) {
-		if (fs.existsSync(__dirname + `/lang/${lang.replace(/-.*$/, "")}.json`)) {
-			lang = lang.replace(/-.*$/, "");
-		} else {
-			lang = "en"; // Uses fallback if language doesn't exist
+function _loadTranslation() {
+	if (fs.existsSync("viper.json")) {
+		lang = JSON.parse(fs.readFileSync("viper.json", "utf8")).lang;
+		if (! lang) {lang = "en"}
+		if (! fs.existsSync(__dirname + `/lang/${lang}.json`)) {
+			if (fs.existsSync(__dirname + `/lang/${lang.replace(/-.*$/, "")}.json`)) {
+				lang = lang.replace(/-.*$/, "");
+			} else {
+				lang = "en";
+			}
 		}
 	}
+	langObj = JSON.parse(fs.readFileSync(__dirname + `/lang/${lang}.json`, "utf8"));
 }
 
-var langObj = JSON.parse(fs.readFileSync(__dirname + `/lang/${lang}.json`, "utf8"));
 
 module.exports = (string) => {
-	if (langObj[string]) { // Returns string from language
+	_loadTranslation();
+
+	if (langObj[string]) {
 		return langObj[string];
-	} else { // If string doesn't exist
-		if (langDef[string]) { // Retrieves from default lang instead
-			return langDef[string];
+	} else {
+		if (enLang[string]) {
+			return enLang[string];
 		} else {
 			// If it's not in the default lang either, it returns the
 			// string, this is absolute fallback.

--- a/src/lang.js
+++ b/src/lang.js
@@ -1,7 +1,7 @@
 const fs = require("fs");
 
 const enLang = JSON.parse(fs.readFileSync(__dirname + `/lang/en.json`, "utf8"));
-let lang = "en";
+let lang = "";
 var langObj = {};
 
 
@@ -16,13 +16,16 @@ function _loadTranslation() {
 				lang = "en";
 			}
 		}
+	} else {
+		lang = "en";
 	}
 	langObj = JSON.parse(fs.readFileSync(__dirname + `/lang/${lang}.json`, "utf8"));
 }
 
 
 module.exports = (string) => {
-	_loadTranslation();
+	if (lang === "")
+		_loadTranslation();
 
 	if (langObj[string]) {
 		return langObj[string];


### PR DESCRIPTION
Up-to-date newest version of #28 (cherry-picking commits).

---

Lang module was loaded from different contexts, and initialization code was not properly called in some of them.
Fixed this by loading localisation file (if not already done in current context) each time a translation is needed.

- [x] Avoid loading translations file on each `lang()` call
- [ ] Use default language on first viper launch

---

Fixes #20.