### PR TITLE
feat: GitHub markdown

### DIFF
--- a/src/app/launcher.js
+++ b/src/app/launcher.js
@@ -46,6 +46,7 @@ ipcRenderer.on("ns-notes", (event, response) => {
 			+ release.body.replaceAll("\r\n", "\nhtmlbreak") + "\n\n\n";
 	}
 
+	content = content.replaceAll(/\@(\S+)/g, `<a href="https://github.com/$1">@$1</a>`);
 	nsRelease.innerHTML = markdown(content).replaceAll("htmlbreak", "<br>");
 });
 

--- a/src/app/launcher.js
+++ b/src/app/launcher.js
@@ -20,6 +20,10 @@ function page(page) {
 }; page(0)
 
 
+function enrichMarkdown(content) {
+	return content.replaceAll(/\@(\S+)/g, `<a href="https://github.com/$1">@$1</a>`);
+}
+
 // Updates the Viper release notes
 ipcRenderer.on("vp-notes", (event, response) => {
 	let content = "";
@@ -46,7 +50,7 @@ ipcRenderer.on("ns-notes", (event, response) => {
 			+ release.body.replaceAll("\r\n", "\nhtmlbreak") + "\n\n\n";
 	}
 
-	content = content.replaceAll(/\@(\S+)/g, `<a href="https://github.com/$1">@$1</a>`);
+	content = enrichMarkdown(content);
 	nsRelease.innerHTML = markdown(content).replaceAll("htmlbreak", "<br>");
 });
 

--- a/src/app/launcher.js
+++ b/src/app/launcher.js
@@ -33,6 +33,7 @@ ipcRenderer.on("vp-notes", (event, response) => {
 			+ release.body.replaceAll("\r\n", "\n") + "\n\n\n";
 	}
 
+	content = enrichMarkdown(content);
 	vpReleaseNotes.innerHTML = markdown(content);
 });
 


### PR DESCRIPTION
The other day, while checking release notes, I saw some elements that should link to GitHub, but didn't.
These include issues links, pull requests links and author mentions (I suppose they are custom GitHub Markdown?)
Anyway, I wanted them to behave on Viper as they do on GitHub.

---

##### TODOs

- [x] Author mentions
- [ ] Issues/PR links

I did not figure how to implement last item, because both have same format (`#11`).
[Actually, issues link seem to work for Northstar notes, but not for Viper notes? In Viper, NS issue is correctly converted to link ([https://github.com/R2Northstar/Northstar/releases/tag/v1.4.1](https://github.com/R2Northstar/Northstar/releases/tag/v1.4.1)) while VP issue is not ([https://github.com/0neGal/viper/releases/tag/v1.0.3](https://github.com/0neGal/viper/releases/tag/v1.0.3))]

---

## Author mentions

#### Before

![Capture d’écran de 2022-02-24 08-03-03](https://user-images.githubusercontent.com/11993538/155476271-11139544-23e4-4999-a781-87b229adefdd.png)

#### After

![Capture d’écran de 2022-02-24 08-01-51](https://user-images.githubusercontent.com/11993538/155476222-6436a155-5969-451c-95bd-2a5d93cf854e.png)
