### PR TITLE
fix: nsargs clearing when edited outside of Viper

### DIFF
--- a/src/app/main.js
+++ b/src/app/main.js
@@ -33,6 +33,11 @@ if (fs.existsSync("viper.json")) {
 	} else {
 		setpath(true);
 	}
+
+	let args = path.join(settings.gamepath, "ns_startup_args.txt");
+	if (fs.existsSync(args)) {
+		settings.nsargs = fs.readFileSync(args, "utf8");
+	}
 } else {
 	setpath();
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -39,6 +39,11 @@ var settings = {
 if (fs.existsSync("viper.json")) {
 	settings = {...settings, ...JSON.parse(fs.readFileSync("viper.json", "utf8"))};
 	settings.zip = path.join(settings.gamepath + "/northstar.zip");
+
+	let args = path.join(settings.gamepath, "ns_startup_args.txt");
+	if (fs.existsSync(args)) {
+		settings.nsargs = fs.readFileSync(args, "utf8");
+	}
 } else {
 	console.log(lang("general.missingpath"));
 }


### PR DESCRIPTION
If the nsargs are edited by a third-party program or anything that isn't Viper, the next time you launch Viper it'll reset the nsargs back to what it was when you last opened it.
