### PR TITLE
fix: VDF path searching not working on SteamDeck

### DIFF
--- a/src/extras/findgame.js
+++ b/src/extras/findgame.js
@@ -36,7 +36,10 @@ module.exports = async () => {
 			let data_array = Object.values(data["libraryfolders"][pathIterator])
 			
 			if (fs.existsSync(data_array[0] + "/steamapps/common/Titanfall2/Titanfall2.exe")) {
+				console.log("Found game in:", data_array[0])
 				return data_array[0] + "/steamapps/common/Titanfall2";
+			} else {
+				console.log("Game not found in:", data_array[0])
 			}
 		}
 	}
@@ -54,6 +57,7 @@ module.exports = async () => {
 	}
 
 	if (fs.existsSync(folder) && folder) {
+		console.log("VDF file found at:", folder)
 		let data = fs.readFileSync(folder)
 		let read_vdf = readvdf(data.toString())
 		if (read_vdf ) {return read_vdf}

--- a/src/extras/findgame.js
+++ b/src/extras/findgame.js
@@ -31,6 +31,8 @@ module.exports = async () => {
 		// Parse read_data
 		data = vdf.parse(data);
 
+		console.log(data)
+
 		// `.length - 1` This is because the last value is `contentstatsid`
 		for (let pathIterator = 0; pathIterator < Object.values(data["libraryfolders"]).length - 1; pathIterator++) {
 			let data_array = Object.values(data["libraryfolders"][pathIterator])

--- a/src/extras/findgame.js
+++ b/src/extras/findgame.js
@@ -31,21 +31,19 @@ module.exports = async () => {
 		// Parse read_data
 		data = vdf.parse(data);
 
-		console.log(data)
-
+		let values = Object.values(data["libraryfolders"]);
+		if (typeof values[values.length - 1] != "object") {
+			values.pop(1);
+		}
+		
 		// `.length - 1` This is because the last value is `contentstatsid`
-		for (let i = 0; i < Object.values(data["libraryfolders"]).length - 1; i++) {
-			console.log("test1")
-			let data_array = Object.values(data["libraryfolders"][i])
-			console.log("test2")
+		for (let i = 0; i < values.length; i++) {
+			let data_array = Object.values(values[i])
 			
 			if (fs.existsSync(data_array[0] + "/steamapps/common/Titanfall2/Titanfall2.exe")) {
 				console.log("Found game in:", data_array[0])
 				return data_array[0] + "/steamapps/common/Titanfall2";
-			} else {
-				console.log("Game not found in:", data_array[0])
 			}
-			console.log("test3")
 		}
 	}
 
@@ -62,7 +60,6 @@ module.exports = async () => {
 	}
 
 	if (fs.existsSync(folder) && folder) {
-		console.log("VDF file found at:", folder)
 		let data = fs.readFileSync(folder)
 		let read_vdf = readvdf(data.toString())
 		if (read_vdf ) {return read_vdf}

--- a/src/extras/findgame.js
+++ b/src/extras/findgame.js
@@ -34,8 +34,10 @@ module.exports = async () => {
 		console.log(data)
 
 		// `.length - 1` This is because the last value is `contentstatsid`
-		for (let pathIterator = 0; pathIterator < Object.values(data["libraryfolders"]).length - 1; pathIterator++) {
-			let data_array = Object.values(data["libraryfolders"][pathIterator])
+		for (let i = 0; i < Object.values(data["libraryfolders"]).length - 1; i++) {
+			console.log("test1")
+			let data_array = Object.values(data["libraryfolders"][i])
+			console.log("test2")
 			
 			if (fs.existsSync(data_array[0] + "/steamapps/common/Titanfall2/Titanfall2.exe")) {
 				console.log("Found game in:", data_array[0])
@@ -43,6 +45,7 @@ module.exports = async () => {
 			} else {
 				console.log("Game not found in:", data_array[0])
 			}
+			console.log("test3")
 		}
 	}
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -769,6 +769,8 @@ setInterval(() => {
 	ipcMain.emit("guigetmods");
 }, 1500)
 
+console.log(findgame())
+
 module.exports = {
 	mods,
 	lang,


### PR DESCRIPTION
For some reason the path to the game on SteamDeck doesn't seem to be able to be found automatically. Even though VDF reading should work just fine.

Essentially this branch is just for testing, and inevitably fixing the issue.
