### PR TITLE
feat: Dependency support

### DIFF
--- a/src/app/browser.js
+++ b/src/app/browser.js
@@ -171,7 +171,8 @@ function BrowserElFromObj(obj) {
 		download: pkg.download_url,
 		version: pkg.version_number,
 		categories: pkg.categories,
-		description: pkg.description
+		description: pkg.description,
+		dependencies: pkg.dependencies,
 	})
 }
 
@@ -240,7 +241,7 @@ function BrowserEl(properties) {
 			<div class="text">
 				<div class="title">${properties.title}</div>
 				<div class="description">${properties.description}</div>
-				<button class="install" onclick="installFromURL('${properties.download}')">${installstr}</button>
+				<button class="install" onclick='installFromURL("${properties.download}", ${JSON.stringify(properties.dependencies)}, true)'>${installstr}</button>
 				<button class="info" onclick="require('electron').shell.openExternal('${properties.url}')">${lang('gui.browser.info')}</button>
 				<button class="visual">${properties.version}</button>
 				<button class="visual">${lang("gui.browser.madeby")} ${properties.author}</button>
@@ -285,6 +286,11 @@ ipcRenderer.on("installedmod", (event, mod) => {
 		title: lang("gui.toast.title.installed"),
 		description: mod.name + " " + lang("gui.toast.desc.installed")
 	})
+
+	if (installqueue.length != 0) {
+		installFromURL("https://thunderstore.io/package/download/" + installqueue[0]);
+		installqueue.shift();
+	}
 })
 
 function normalize(items) {

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -190,6 +190,8 @@ function selected(all) {
 	}
 }
 
+let installqueue = [];
+
 // Tells the main process to install a mod through the file selector
 function installmod() {
 	setButtons(false);
@@ -203,9 +205,40 @@ function installFromPath(path) {
 }
 
 // Tells the main process to install a mod from a URL
-function installFromURL(url) {
+function installFromURL(url, dependencies, clearqueue) {
+	if (clearqueue) {installqueue = []};
+	console.log(installqueue)
+
+	let prettydepends = [];
+
+	if (dependencies) {
+		let newdepends = [];
+		for (let i = 0; i < dependencies.length; i++) {
+			let depend = dependencies[i].toLowerCase();
+			console.log(depend)
+			if (! depend.match(/northstar-northstar-.*/)) {
+				newdepends.push(dependencies[i].replaceAll("-", "/"));
+				let pkg = newdepends[newdepends.length - 1].split("/");
+				prettydepends.push(`${pkg[1]} v${pkg[2]} - ${lang("gui.browser.madeby")} ${pkg[0]}`);
+			}
+		}
+
+		dependencies = newdepends;
+	} 
+
+	if (dependencies && dependencies.length != 0) {
+		let confirminstall = confirm(lang("gui.mods.confirmdependencies") + prettydepends.join("\n"));
+		if (! confirminstall) {
+			return
+		}
+	}
+
 	setButtons(false);
-	ipcRenderer.send("installfromurl", url)
+	ipcRenderer.send("installfromurl", url, dependencies)
+
+	if (dependencies) {
+		installqueue = dependencies;
+	}
 }
 
 // Frontend part of settings a new game path

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -217,9 +217,12 @@ function installFromURL(url, dependencies, clearqueue) {
 			let depend = dependencies[i].toLowerCase();
 			console.log(depend)
 			if (! depend.match(/northstar-northstar-.*/)) {
-				newdepends.push(dependencies[i].replaceAll("-", "/"));
-				let pkg = newdepends[newdepends.length - 1].split("/");
-				prettydepends.push(`${pkg[1]} v${pkg[2]} - ${lang("gui.browser.madeby")} ${pkg[0]}`);
+				depend = dependencies[i].replaceAll("-", "/");
+				let pkg = depend.split("/");
+				if (! isModInstalled(pkg[1])) {
+					newdepends.push(depend);
+					prettydepends.push(`${pkg[1]} v${pkg[2]} - ${lang("gui.browser.madeby")} ${pkg[0]}`);
+				}
 			}
 		}
 
@@ -239,6 +242,21 @@ function installFromURL(url, dependencies, clearqueue) {
 	if (dependencies) {
 		installqueue = dependencies;
 	}
+}
+
+function isModInstalled(modname) {
+	for (let i = 0; i < modsobj.all.length; i++) {
+		let mod = modsobj.all[i];
+		if (mod.ManifestName) {
+			if (mod.ManifestName.match(modname)) {
+				return true;
+			}
+		} else if (mod.Name.match(modname)) {
+			return true;
+		}
+	}
+
+	return false;
 }
 
 // Frontend part of settings a new game path

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -68,6 +68,7 @@
 	"gui.mods.installing": "Installing mod...",
 	"gui.mods.installedmod": "Installed mod!",
 	"gui.mods.dragdrop": "Drag and drop a mod to install",
+	"gui.mods.confirmdependencies": "This package has dependencies, shown below, clicking \"Ok\" will install the package and the dependencies.\n\n",
 
 	"gui.browser.info": "Info",
 	"gui.browser.madeby": "by",

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -68,6 +68,7 @@
 	"gui.mods.installing": "Instalando modificación...",
 	"gui.mods.installedmod": "¡Modificación instalada!",
 	"gui.mods.dragdrop": "Arrastra y suelta una modificación para instalarla",
+	"gui.mods.confirmdependencies": "Este paquete tiene dependencias, se muestran abajo. Presionar \"Ok\" instalará el paquete y las dependencias.\n\n",
 
 	"gui.browser.info": "Información",
 	"gui.browser.madeby": "por",

--- a/src/utils.js
+++ b/src/utils.js
@@ -720,14 +720,6 @@ const mods = {
 			let stream = fs.createWriteStream(modlocation);
 			res.pipe(stream);
 
-			// let received = 0;
-			// // Progress messages, we should probably switch this to
-			// // percentage instead of how much is downloaded.
-			// res.on("data", (chunk) => {
-			// 	received += chunk.length;
-			// 	ipcMain.emit("ns-update-event", lang("gui.update.downloading") + " " + (received / 1024 / 1024).toFixed(1) + "mb");
-			// })
-
 			stream.on("finish", () => {
 				stream.close();
 				mods.install(modlocation);


### PR DESCRIPTION
When merged this PR should allow somebody to click install on packages with dependencies and those dependencies then install.

#### TODO

 - [x] Basic support for dependencies
 - [x] Check if a dependency is already installed

Currently very little is needed to be translated/localized, and I won't yet @ anybody as I have no clue whether it is the final strings, however currently the below strings need translating:

```json
"gui.mods.confirmdependencies": "This package has dependencies, shown below, clicking \"Ok\" will install the package and the dependencies.\n\n",
```

Keep in mind, I won't be merging any i18n PR's until the above strings are the final ones! :)
