### PR TITLE
feat: Master server status

### DIFF
--- a/src/app/css/launcher.css
+++ b/src/app/css/launcher.css
@@ -297,3 +297,32 @@ code {
 	margin-top: calc(var(--spacing) / 2);
 	margin-bottom: calc(var(--spacing) / 2);
 }
+
+#serverstatus {
+	--spacing: calc(var(--padding) / 5);
+	
+	transition-duration: 0.2s;
+	transition-timing-function: ease-in-out;
+	transition-property: background, opacity;
+
+	opacity: 0.0;
+	display: block;
+	margin: 0 auto;
+	font-weight: 700;
+	width: fit-content;
+	color: transparent;
+	border-radius: 50px;
+	flex-basis: max-content;
+	background: transparent;
+	margin-top: calc(var(--spacing) * 2);
+	padding: var(--spacing) calc(var(--spacing) * 3);
+}
+
+#serverstatus.up,
+#serverstatus.down {
+	color: white;
+	opacity: 1.0;
+}
+
+#serverstatus.up {background: rgb(var(--blue));}
+#serverstatus.down {background: rgb(var(--red));}

--- a/src/app/index.html
+++ b/src/app/index.html
@@ -197,6 +197,7 @@
 							<div class="inline">
 								<div id="nsversion"></div>
 								<a id="update" href="#" onclick="update()">(%%gui.update.check%%)</a>
+								<div id="serverstatus" class="checking"></div>
 							</div>
 						</div>
 					</div>
@@ -240,4 +241,4 @@
 		<script src="settings.js"></script>
 		<script src="launcher.js"></script>
 	</body>
-</html>
+<

--- a/src/app/launcher.js
+++ b/src/app/launcher.js
@@ -1,5 +1,9 @@
 const markdown = require("marked").parse;
 
+var servercount;
+var playercount;
+var masterserver;
+
 // Changes the main page
 // This is the tabs in the sidebar
 function page(page) {
@@ -107,3 +111,39 @@ function showNsSection(section) {
 			break;
 	}
 }
+
+async function loadServers() {
+	serverstatus.classList.add("checking");
+
+	try {
+		let servers = await (await fetch("https://northstar.tf/client/servers/")).json();
+		masterserver = true;
+	}catch (err) {
+		playercount = 0;
+		servercount = 0;
+		masterserver = false;
+	}
+
+	serverstatus.classList.remove("checking");
+
+	if (servercount == 0) {masterserver = false}
+
+	if (masterserver) {
+		serverstatus.classList.add("up");
+		// servercount and playercount don't actually get set anywhere,
+		// the reason for this is, while writing this code, the master
+		// server is down so I don't have anyway to test the code...
+		//
+		// it'll be added whenever the masterserver comes online again.
+		serverstatus.innerHTML = `${servercount} ${lang("gui.server.servers")} - ${playercount} ${lang("gui.server.players")}`;
+	} else {
+		serverstatus.classList.add("down");
+		serverstatus.innerHTML = lang("gui.server.offline");
+
+	}
+}; loadServers()
+
+// Refreshes every 5 minutes
+setInterval(() => {
+	loadServers();
+}, 300000)

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -113,6 +113,10 @@
 	"gui.nsupdate.gaming.title": "Northstar update available!",
 	"gui.nsupdate.gaming.body": "An update for Northstar is available.\nYou can force its installation after closing the game.",
 
+	"gui.server.servers": "servers",
+	"gui.server.players": "players",
+	"gui.server.offline": "Masterserver is Offline",
+
 	"gui.launch": "Launch",
 	"gui.launchvanilla": "Vanilla",
 	"gui.launchnorthstar": "Northstar",


### PR DESCRIPTION
When merged this'll add an indicator on whether the masterserver is currently online or offline, it'll also show the current amount of players and servers. This'll help clear confusion when people get authentication errors just because the master server is down.

#### TODO

 - [x] Frontend
 - [ ] Localizations
   - [ ] French (`fr.json`)
   - [ ] Spanish (`es.json`)
 - [ ] Fully Implement
   - Because the masterserver is down while making this PR I can't fully implement everything, such as the player counts and the servers counts, I will do these whenever the server comes back online

#### LOCALIZATION

I doubt there's anything that's going to change so feel free to make the PR's to localize everything whenever possible. @Alystrasz @AA-Delta

```json
"gui.server.servers": "servers",
"gui.server.players": "players",
"gui.server.offline": "Masterserver is Offline",
```

The first two strings are used for the status, on an English client it'd become `0 servers - 0 players`
