### PR TITLE
Update linked mod managers. Add Papa, remove Ronin

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Some of the existing launchers are listed below:
  * [Ronin](https://github.com/MindSwipe/ronin) - a CLI only updater
  * [VTOL](https://github.com/BigSpice/VTOL) - an updater and manager for mods, very feature rich
  * [r2modman](https://github.com/ebkr/r2modmanPlus) - General purpose mod manager, which has support for Northstar
+ * [Papa](https://github.com/AnActualEmerald/papa/) - a CLI only installer, updater, and mod manager
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ Given that we already have so many Northstar updaters and launchers I urge peopl
 Some of the existing launchers are listed below:
  * Viper - A launcher, updater and mod manager with an easy to use GUI
  * [ViperSH](https://github.com/0neGal/viper-sh) - A Bourne Shell, CLI only, Northstar updater and mod manager
- * [Ronin](https://github.com/MindSwipe/ronin) - a CLI only updater
  * [VTOL](https://github.com/BigSpice/VTOL) - an updater and manager for mods, very feature rich
  * [r2modman](https://github.com/ebkr/r2modmanPlus) - General purpose mod manager, which has support for Northstar
  * [Papa](https://github.com/AnActualEmerald/papa/) - a CLI only installer, updater, and mod manager


### PR DESCRIPTION
Removed [Ronin](https://github.com/MindSwipe/ronin) due to not having seen a single update since half a year. Back then the release zip file had a slightly different folder structure so it's likely that this installer doesn't even function properly anymore.

Added [Papa](https://github.com/AnActualEmerald/papa/), a new CLI only installer, updater, and mod-manager, designed for use with servers.