### PR TITLE
feat: No internet handling

### DIFF
--- a/src/app/browser.js
+++ b/src/app/browser.js
@@ -392,7 +392,6 @@ ipcRenderer.on("failed-mod", (event, modname) => {
 })
 
 ipcRenderer.on("no-internet", (event, modname) => {
-	console.log('yo')
 	setButtons(true);
 	new Toast({
 		timeout: 10000,

--- a/src/app/browser.js
+++ b/src/app/browser.js
@@ -391,6 +391,17 @@ ipcRenderer.on("failed-mod", (event, modname) => {
 	})
 })
 
+ipcRenderer.on("no-internet", (event, modname) => {
+	console.log('yo')
+	setButtons(true);
+	new Toast({
+		timeout: 10000,
+		scheme: "error",
+		title: lang("gui.toast.noInternet.title"),
+		description: lang("gui.toast.noInternet.desc")
+	})
+})
+
 ipcRenderer.on("installed-mod", (event, mod) => {
 	setButtons(true);
 	Browser.setbutton(mod.name, lang("gui.browser.reinstall"));

--- a/src/app/launcher.js
+++ b/src/app/launcher.js
@@ -26,12 +26,16 @@ function page(page) {
 function formatRelease(notes) {
 	let content = "";
 
-	for (let release of notes) {
-		if (release.prerelease) {continue}
-		content += "# " + release.name + "\n\n"	+ release.body + "\n\n\n";
+	if (notes.length === 1) {
+		content = notes[0];
+	} else {
+		for (let release of notes) {
+			if (release.prerelease) {continue}
+			content += "# " + release.name + "\n\n"	+ release.body + "\n\n\n";
+		}
+	
+		content = content.replaceAll(/\@(\S+)/g, `<a href="https://github.com/$1">@$1</a>`);
 	}
-
-	content = content.replaceAll(/\@(\S+)/g, `<a href="https://github.com/$1">@$1</a>`);
 
 	return markdown(content, {
 		breaks: true

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -1,6 +1,6 @@
 const fs = require("fs");
 const path = require("path");
-const { ipcRenderer, shell } = require("electron");
+const { ipcRenderer, shell, ipcMain } = require("electron");
 
 const lang = require("../lang");
 var modsobj = {};
@@ -61,6 +61,11 @@ if (fs.existsSync("viper.json")) {
 } else {
 	setpath();
 }
+
+
+// Show a toast message if no Internet connection has been detected.
+if (!navigator.onLine) 
+	ipcRenderer.send("no-internet");
 
 function exit() {ipcRenderer.send("exit")}
 function update() {ipcRenderer.send("update")}

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -122,6 +122,7 @@ ipcRenderer.on("ns-update-event", (event, key) => {
 	console.log(lang(key));
 	switch(key) {
 		case "cli.update.uptodate.short":
+		case "cli.update.noInternet":
 			setButtons(true);
 			playNsBtn.innerText = lang("gui.launch");
 			break;

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -64,8 +64,9 @@ if (fs.existsSync("viper.json")) {
 
 
 // Show a toast message if no Internet connection has been detected.
-if (!navigator.onLine) 
+if (!navigator.onLine) {
 	ipcRenderer.send("no-internet");
+}
 
 function exit() {ipcRenderer.send("exit")}
 function update() {ipcRenderer.send("update")}

--- a/src/extras/requests.js
+++ b/src/extras/requests.js
@@ -58,6 +58,11 @@ async function getLatestNsVersion() {
                     _saveCache(cache);
                     resolve( cache[NORTHSTAR_LATEST_RELEASE_KEY]["body"]["tag_name"] );
                 });
+            })
+            
+            .on('error', () => {
+                console.error('Failed to get latest Northstar version.');
+                resolve( false );
             });
         }
     });

--- a/src/extras/requests.js
+++ b/src/extras/requests.js
@@ -103,6 +103,20 @@ async function getNsReleaseNotes() {
                     _saveCache(cache);
                     resolve( cache[NORTHSTAR_RELEASE_NOTES_KEY]["body"] );
                 });
+            })
+            
+            // When GitHub cannot be reached (when user doesn't have Internet 
+            // access for instance), we return latest cache content even if 
+            // it's not up-to-date, or display an error message if cache
+            // is empty.
+            .on('error', () => {
+                if ( cache[NORTHSTAR_RELEASE_NOTES_KEY] ) {
+                    console.warn("Couldn't fetch Northstar release notes, returning data from cache.");
+                    resolve( cache[NORTHSTAR_RELEASE_NOTES_KEY]["body"] );
+                } else {
+                    console.error("Couldn't fetch Northstar release notes, cache is empty.");
+                    resolve( ["Couldn't fetch Northstar release notes.\nTry again later!"] );
+                }
             });
         }
     });
@@ -140,6 +154,20 @@ async function getVpReleaseNotes() {
                     _saveCache(cache);
                     resolve( cache[VIPER_RELEASE_NOTES_KEY]["body"] );
                 });
+            })
+
+            // When GitHub cannot be reached (when user doesn't have Internet 
+            // access for instance), we return latest cache content even if 
+            // it's not up-to-date, or display an error message if cache
+            // is empty.
+            .on('error', () => {
+                if ( cache[VIPER_RELEASE_NOTES_KEY] ) {
+                    console.warn("Couldn't fetch Viper release notes, returning data from cache.");
+                    resolve( cache[VIPER_RELEASE_NOTES_KEY]["body"] );
+                } else {
+                    console.error("Couldn't fetch Viper release notes, cache is empty.");
+                    resolve( ["Couldn't fetch Viper release notes.\nTry again later!"] );
+                }
             });
         }
     });

--- a/src/extras/requests.js
+++ b/src/extras/requests.js
@@ -2,6 +2,7 @@ const { app } = require("electron");
 const path = require("path");
 const fs = require("fs");
 const { https } = require("follow-redirects");
+const lang = require("../lang");
 
 
 // all requests results are stored in this file
@@ -120,7 +121,7 @@ async function getNsReleaseNotes() {
                     resolve( cache[NORTHSTAR_RELEASE_NOTES_KEY]["body"] );
                 } else {
                     console.error("Couldn't fetch Northstar release notes, cache is empty.");
-                    resolve( ["Couldn't fetch Northstar release notes.\nTry again later!"] );
+                    resolve( [lang("request.northstar.noReleaseNotes")] );
                 }
             });
         }
@@ -171,7 +172,7 @@ async function getVpReleaseNotes() {
                     resolve( cache[VIPER_RELEASE_NOTES_KEY]["body"] );
                 } else {
                     console.error("Couldn't fetch Viper release notes, cache is empty.");
-                    resolve( ["Couldn't fetch Viper release notes.\nTry again later!"] );
+                    resolve( [lang("request.viper.noReleaseNotes")] );
                 }
             });
         }

--- a/src/index.js
+++ b/src/index.js
@@ -71,6 +71,7 @@ function start() {
 	ipcMain.on("removed-mod", (event, modname) => {send("removed-mod", modname)});
 	ipcMain.on("gui-getmods", (event, ...args) => {send("mods", utils.mods.list())});
 	ipcMain.on("installed-mod", (event, modname) => {send("installed-mod", modname)});
+	ipcMain.on("no-internet", () => {send("no-internet")});
 
 	// install calls
 	ipcMain.on("install-from-path", (event, path) => {utils.mods.install(path)});

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -22,6 +22,7 @@
 	"cli.update.finished": "Installation/Aktualisierung abeschlossen!",
 	"cli.update.uptodate": "Installation ist bereits auf dem neusten Stand (%s), aktualisieren wird übersprungen.",
 	"cli.update.uptodate.short": "Auf dem neusten stand",
+	"cli.update.noInternet": "Keine Internetverbindung",
 
 	"cli.autoupdates.checking": "Überprüfe Northstar auf Updates...",
 	"cli.autoupdates.available": "Ein Update für Northstar wurde gefunden!",
@@ -137,6 +138,9 @@
 	"gui.toast.desc.malformed": "hat eine fehlerhafte Ordnerstruktur, falls du der Entwickler bist, solltest du dies beheben.",
 	"gui.toast.desc.failed": "Ein unbekannter Fehler ist aufgetaucht beim Installieren, die Schuld kann beim Autor liegen oder bei Viper selbst!",
 
+	"gui.toast.noInternet.title": "Kein Internet",
+	"gui.toast.noInternet.desc": "Viper funktioniert möglicherweise nicht korrekt",
+
 	"viper.menu.main": "Viper",
 	"viper.menu.release": "Release Notes",
 	"viper.menu.info": "Extras",
@@ -156,5 +160,8 @@
 	"general.missingpath": "Installationspfad konnte nicht automatisch gefunden werden, bitte setze diesen manuell!",
 	"general.notinstalled": "Northstar ist nicht installiert!",
 	"general.launching": "Starte!",
-	"general.invalidconfig": "Deine Konfigurationsdatei ist nicht richtig formatiert, falls diese manuell verändert wurde bitte stelle sicher das alles korrekt ist.\n\nFalls du diese nicht manuell verändert hast, ist es empfohlen diese zurückzusetzen!\n\nUm sie zurückzusetzen drücke einfach auf \"Ok\".\n\nWeitere Informationen:\n"
+	"general.invalidconfig": "Deine Konfigurationsdatei ist nicht richtig formatiert, falls diese manuell verändert wurde bitte stelle sicher das alles korrekt ist.\n\nFalls du diese nicht manuell verändert hast, ist es empfohlen diese zurückzusetzen!\n\nUm sie zurückzusetzen drücke einfach auf \"Ok\".\n\nWeitere Informationen:\n",
+
+	"request.viper.noReleaseNotes": "Viper Release Notes konnten nicht geladen werden.\nVersuche es erneut später!",
+	"request.northstar.noReleaseNotes": "Northstar Release Notes konnten nicht geladen werden.\nVersuche es erneut später!"
 }

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -139,6 +139,9 @@
 	"gui.toast.desc.malformed": "has an incorrect folder structure, if you're the developer, you should fix this.",
 	"gui.toast.desc.failed": "An unknown error occurred while trying to install the mod. This may be the author's fault, and it may also be Viper's fault.",
 
+	"gui.toast.noInternet.title": "No Internet",
+	"gui.toast.noInternet.desc": "Viper may not work properly.",
+
 	"viper.menu.main": "Viper",
 	"viper.menu.release": "Release Notes",
 	"viper.menu.info": "Extras",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -161,5 +161,8 @@
 	"general.missingpath": "Game location could not be found automatically! Please select it manually!",
 	"general.notinstalled": "Northstar is not installed!",
 	"general.launching": "Launching",
-	"general.invalidconfig": "Your config file is improperly formatted, if it's been manually edited, please validate that everything is typed correctly.\n\nIf you did not manually edit the config file, it is recommended to simply reset the config.\n\nTo reset your config file simply click \"Ok\" below.\n\nMore details:\n"
+	"general.invalidconfig": "Your config file is improperly formatted, if it's been manually edited, please validate that everything is typed correctly.\n\nIf you did not manually edit the config file, it is recommended to simply reset the config.\n\nTo reset your config file simply click \"Ok\" below.\n\nMore details:\n",
+
+	"request.viper.noReleaseNotes": "Couldn't fetch Viper release notes.\nTry again later!",
+	"request.northstar.noReleaseNotes": "Couldn't fetch Northstar release notes.\nTry again later!"
 }

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -22,6 +22,7 @@
 	"cli.update.finished": "Installation/Update finished!",
 	"cli.update.uptodate": "Latest version (%s) is already installed, skipping update.",
 	"cli.update.uptodate.short": "Up-to-date",
+	"cli.update.noInternet": "No Internet connection",
 
 	"cli.autoupdates.checking": "Checking for Northstar updates...",
 	"cli.autoupdates.available": "Northstar update available!",

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -24,6 +24,7 @@
 	"cli.update.finished": "Instalación/Actualización completada!",
 	"cli.update.uptodate": "La ultima versión (%s) ya está instalada, omitiendo actualización.",
 	"cli.update.uptodate.short": "Está actualizado",
+	"cli.update.noInternet": "Sin conexión a internet",
 
 	"cli.autoupdates.checking": "Buscando actualizaciones de Northstar...",
 	"cli.autoupdates.available": "¡Actualización de Northsar disponible!",
@@ -137,6 +138,9 @@
 	"gui.server.players": "jugadores",
 	"gui.server.servers": "servidores",
 	"gui.server.offline": "El servidor Master está desconectado",
+
+	"gui.toast.noInternet.title": "Sin Internet",
+	"gui.toast.noInternet.desc": "Viper puede funcionar de forma incorrecta.",
 	
 	"viper.menu.main": "Viper",
 	"viper.menu.release": "Notas de la versión",
@@ -157,5 +161,8 @@
 	"general.missingpath": "¡La ruta del jueno no se ha podido encontrar automaticamente! ¡Por favor, elige la ruta manualmente!",
 	"general.notinstalled": "¡Northstar no se ha instalado!",
 	"general.launching": "Ejecutando",
-	"general.invalidconfig": "Su archivo de configuración está formateado de forma incorrecta, si ha sido editado manualmente, por favor valide que ha sido escrito correctamente. \n\nSi no ha editado manualmente el archivo de configuración, es recomendado que simplemente restaure la configuración. \n\nPara restaurar tu configuración simplemente de click en \"OK\" a continuación. \n\nMas detalles:\n"
+	"general.invalidconfig": "Su archivo de configuración está formateado de forma incorrecta, si ha sido editado manualmente, por favor valide que ha sido escrito correctamente. \n\nSi no ha editado manualmente el archivo de configuración, es recomendado que simplemente restaure la configuración. \n\nPara restaurar tu configuración simplemente de click en \"OK\" a continuación. \n\nMas detalles:\n",
+
+	"request.viper.noReleaseNotes": "No se pudo encontrar las notas de lanzamiento de Viper.\n¡Intenta mas tarde!",
+	"request.northstar.noReleaseNotes": "No se pudo encontrar las notas de lanzamiento de Northstar.\n¡Intenta mas tarde!"
 }

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -161,5 +161,8 @@
 	"general.missingpath": "Le chemin du client n'a pu être trouvé automatiquement, merci de le sélectionner manuellement.",
 	"general.notinstalled": "Northstar n'est pas installé !",
 	"general.launching": "Lancement",
-	"general.invalidconfig": "Votre fichier de configuration n'est pas formaté correctement ; si vous l'avez manuellement édité, veuillez vérifier son contenu.\n\nSinon, il est recommandé de remettre la configuration à zéro.\n\nPour cela, cliquez sur le bouton \"Ok\" en-dessous de ce message.\n\nPlus d'informations :\n"
+	"general.invalidconfig": "Votre fichier de configuration n'est pas formaté correctement ; si vous l'avez manuellement édité, veuillez vérifier son contenu.\n\nSinon, il est recommandé de remettre la configuration à zéro.\n\nPour cela, cliquez sur le bouton \"Ok\" en-dessous de ce message.\n\nPlus d'informations :\n",
+
+	"request.viper.noReleaseNotes": "Impossible de récupérer les notes de mises à jour de Viper.\nVeuillez réessayer plus tard.",
+	"request.northstar.noReleaseNotes": "Impossible de récupérer les notes de mises à jour de Northstar.\nVeuillez réessayer plus tard."
 }

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -139,6 +139,9 @@
 	"gui.toast.desc.malformed": "a une structure de dossier incorrecte ; si vous êtes son développeur, vous devriez réparer ça.",
 	"gui.toast.desc.failed": "Une erreur inconnue est survenue lors de l'installation du mod. Cela peut être du ressort de l'auteur du mod ou de Viper.",
 
+	"gui.toast.noInternet.title": "Pas de connexion Internet",
+	"gui.toast.noInternet.desc": "Viper ne fonctionnera pas correctement tant que la connexion n'est pas rétablie.",
+
 	"viper.menu.main": "Viper",
 	"viper.menu.release": "Notes de mises à jour",
 	"viper.menu.info": "Informations",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -22,6 +22,7 @@
 	"cli.update.finished": "Mise à jour terminée !",
 	"cli.update.uptodate": "La dernière version (%s) est déjà installée.",
 	"cli.update.uptodate.short": "Votre client est à jour",
+	"cli.update.noInternet": "Pas de connexion Internet",
 
 	"cli.autoupdates.checking": "Vérifications des mises à jour de Northstar...",
 	"cli.autoupdates.available": "Une mise à jour de Northstar est disponible !",

--- a/src/utils.js
+++ b/src/utils.js
@@ -155,7 +155,7 @@ function handleNorthstarUpdating() {
 	async function _checkForUpdates() {
 		let localVersion = getNSVersion();
 		let distantVersion = await requests.getLatestNsVersion();
-		if (distantVersion == false) return;
+		if (distantVersion == false) { return; }
 		console.log(lang("cli.autoupdates.checking"));
 
 		// Checks if NS is outdated

--- a/src/utils.js
+++ b/src/utils.js
@@ -155,6 +155,7 @@ function handleNorthstarUpdating() {
 	async function _checkForUpdates() {
 		let localVersion = getNSVersion();
 		let distantVersion = await requests.getLatestNsVersion();
+		if (distantVersion == false) return;
 		console.log(lang("cli.autoupdates.checking"));
 
 		// Checks if NS is outdated
@@ -361,6 +362,10 @@ async function update() {
 
 	const latestAvailableVersion = await requests.getLatestNsVersion();
 	console.log(latestAvailableVersion)
+	if (latestAvailableVersion == false) {
+		ipcMain.emit("ns-update-event", "cli.update.noInternet");
+		return;
+	}
 
 	// Makes sure it is not already the latest version
 	if (version === latestAvailableVersion) {


### PR DESCRIPTION
When release notes (either Northstar or Viper) fetching fails, if cache contains data, we display it even if it's outdated; if cache is empty, we display an error message in place of release notes + a toast message informing user.

Fixes #105.

---

#### Screenshots

![Capture d’écran 2022-08-06 233042](https://user-images.githubusercontent.com/11993538/183266727-d59d5d8f-6d7f-4c53-9921-30e2853b6cfc.png)

![Capture d’écran 2022-08-06 233348](https://user-images.githubusercontent.com/11993538/183266744-e710ded6-b303-45fd-ad9b-26575fa150b3.png)

---

##### TODOs

- [x] Display a toast message if no Internet connection is detected
- [x] Display an error message on Northstar download link if no Internet
- [x] Error messages translation
    - [x] English
    - [x] French
    - [x] German
    - [x] Spanish

##### New translation entries

```json
"cli.update.noInternet": "",
"gui.toast.noInternet.title": "",
"gui.toast.noInternet.desc": "",
"request.viper.noReleaseNotes": "",
"request.northstar.noReleaseNotes": ""
```