### PR TITLE
feat: Localize "Unknown Error!" toasts

### DIFF
--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -134,9 +134,11 @@
 	"gui.toast.title.installed": "Mod installiert!",
 	"gui.toast.title.failed": "Fehler beim Installieren des Mods!",
 	"gui.toast.title.malformed": "Fehlerhafte Ordnerstruktur!",
+	"gui.toast.title.unknown_error": "",
 	"gui.toast.desc.installed": "wurde installiert!",
 	"gui.toast.desc.malformed": "hat eine fehlerhafte Ordnerstruktur, falls du der Entwickler bist, solltest du dies beheben.",
 	"gui.toast.desc.failed": "Ein unbekannter Fehler ist aufgetaucht beim Installieren, die Schuld kann beim Autor liegen oder bei Viper selbst!",
+	"gui.toast.desc.unknown_error": "",
 
 	"gui.toast.noInternet.title": "Kein Internet",
 	"gui.toast.noInternet.desc": "Viper funktioniert möglicherweise nicht korrekt",

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -130,9 +130,11 @@
 	"gui.toast.title.installed": "¡Modificación instalada!",
 	"gui.toast.title.failed": "¡Falló al instalar!",
 	"gui.toast.title.malformed": "¡Estructura de las carpetas incorrecta!",
+	"gui.toast.title.unknown_error": "",
 	"gui.toast.desc.installed": "¡Ha sido instalado exitosamente!",
 	"gui.toast.desc.malformed": "tiene una estructura de carpetas incorrecta, si usted es el desarrollador, debe corregir esto.",
 	"gui.toast.desc.failed": "Se produjo un error desconocido al intentar instalar la modificación. Esto puede ser culpa del autor de la modificación, y también puede ser culpa de Viper.",
+	"gui.toast.desc.unknown_error": "",
 
 	"gui.server.player": "jugador",
 	"gui.server.players": "jugadores",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -135,9 +135,11 @@
 	"gui.toast.title.installed": "Mod installé !",
 	"gui.toast.title.failed": "L'installation a échoué",
 	"gui.toast.title.malformed": "La structure du dossier du mod est incorrecte.",
+	"gui.toast.title.unknown_error": "",
 	"gui.toast.desc.installed": "a été installé avec succès !",
 	"gui.toast.desc.malformed": "a une structure de dossier incorrecte ; si vous êtes son développeur, vous devriez réparer ça.",
 	"gui.toast.desc.failed": "Une erreur inconnue est survenue lors de l'installation du mod. Cela peut être du ressort de l'auteur du mod ou de Viper.",
+	"gui.toast.desc.unknown_error": "",
 
 	"gui.toast.noInternet.title": "Pas de connexion Internet",
 	"gui.toast.noInternet.desc": "Viper ne fonctionnera pas correctement tant que la connexion n'est pas rétablie.",


### PR DESCRIPTION
This PR is for merging localization of the new friendlier error toasts. Replacing the previous default Electron obtuse and unfriendly alert.

#### New localization keys

```json
"gui.toast.title.unknown_error": "Unknown Error!",
"gui.toast.desc.unknown_error": "An unknown error occurred, click for more details. You may want to take a screenshot of the detailed error when filing a bug report.",
```

#### Maintainers

 - [x] German - @DxsSucuk
 - [x] French - @Alystrasz
 - [x] Spanish - @AA-Delta
