### PR TITLE
Add multiple launching methods

### DIFF
--- a/src/app/index.html
+++ b/src/app/index.html
@@ -51,6 +51,19 @@
 						<input>
 					</div>
 				</div>
+				<div class="option" name="nsmethod">
+					<div class="text">
+						%%gui.settings.nsmethod.title%%
+						<div class="desc">
+							%%gui.settings.nsmethod.desc%%
+						</div>
+					</div>
+					<div class="actions">
+						<select>
+							<option></option>
+						</select>
+					</div>
+				</div>
 				<div class="title">
 					<img src="icons/language.png">
 					<h2>%%gui.settings.title.language%%</h2>

--- a/src/app/js/settings.js
+++ b/src/app/js/settings.js
@@ -86,7 +86,28 @@ var Settings = {
 
 		for (let i = 0; i < options.length; i++) {
 			let optName = options[i].getAttribute("name");
-			if (optName == "forcedlang") {
+			if (optName == "nsmethod") {
+				let div = options[i].querySelector("select");
+
+				var launch_methods = {
+					direct: "Direct",
+					steam: "Steam",
+				};
+
+				if (process.platform == "linux") {
+					// No direct launching under Linux
+					delete launch_methods["direct"]
+				}
+
+				div.innerHTML = "";
+				for (let i in launch_methods) {
+					div.innerHTML += `<option value="${i}">${launch_methods[i]}</option>`				
+				}
+
+				div.value = settings.nsmethod;
+				continue;
+			}
+			else if (optName == "forcedlang") {
 				let div = options[i].querySelector("select");
 
 				div.innerHTML = "";

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -9,6 +9,7 @@ let shouldInstallNorthstar = false;
 // Base settings
 var settings = {
 	nsargs: "",
+	nsmethod: "direct",
 	gamepath: "",
 	nsupdate: true,
 	autolang: true,

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -30,7 +30,7 @@
 	"cli.autoupdates.updatingns": "Updateprozess wird gestartet...",
 	"cli.autoupdates.noupdate": "Kein Update für Northstar vorhanden.",
 
-	"cli.launch.linuxerror": "Das Spiel starten ist derzeit nicht auf Linux unterstützt",
+	"cli.launch.linuxerror": "Das Spiel direkt zu starten ist derzeit nicht auf Linux unterstützt",
 
 	"cli.gamepath.lost": "Installationspfad wurde nicht gefunden, bitte stelle sicher das er gemountet ist!",
 

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -30,7 +30,7 @@
 	"cli.autoupdates.updatingns": "Launching update process...",
 	"cli.autoupdates.noupdate": "No Northstar update available.",
 
-	"cli.launch.linuxerror": "Launching the game is not currently supported on Linux",
+	"cli.launch.linuxerror": "Launching the game directly is not supported on Linux",
 
 	"cli.gamepath.lost": "Gamepath not found, make sure it's mounted!",
 
@@ -93,6 +93,8 @@
 	"gui.settings.title.misc": "Miscellaneous",
 	"gui.settings.nsargs.title": "Launch options",
 	"gui.settings.nsargs.desc": "Here you can add launch options for Northstar/Titanfall.",
+	"gui.settings.nsmethod.title": "Launch Method",
+	"gui.settings.nsmethod.desc": "Choose how to launch Northstar/Titanfall",
 	"gui.settings.autolang.title": "Auto-Detect Language",
 	"gui.settings.autolang.desc": "When enabled, Viper tries to automatically detect your system language, when disabled you can manually change the language below.",
 	"gui.settings.forcedlang.title": "Language",

--- a/src/modules/settings.js
+++ b/src/modules/settings.js
@@ -17,6 +17,7 @@ var settings = {
 	autoupdate: true,
 	originkill: false,
 	nsargs: "-multiple",
+	nsmethod: "direct",
 	zip: "/northstar.zip",
 
 	// These files won't be overwritten when installing/updating


### PR DESCRIPTION
proof-of-concept to look for feedback on if this would be useful or not.

Allows for multiple methods of launching Titanfall/Northstar.

Currently Implemented
 - direct (Windows only)
 - Steam (Linux path hardcoded right now)

Other methods could be:
- Origin
- Lutris
- Wine
