### PR TITLE
Fixes broken JSON files on restart

### DIFF
--- a/src/app/main.js
+++ b/src/app/main.js
@@ -39,7 +39,7 @@ if (fs.existsSync("viper.json")) {
 		if (! reset) {
 			ipcRenderer.send("exit");
 		} else {
-			fs.writeFileSync("viper.json", "{}");
+			fs.rmSync("viper.json");
 			ipcRenderer.send("relaunch");
 		}
 		


### PR DESCRIPTION
On restart, if the json file was broken supposedly would try to repair but it wouldn't work, it would keep repairing but failing. This should fix it by deleting the json file and creating a new one at the start with the correct settings (hopefully)