### PR TITLE
feat: Support for the new packages folder

### DIFF
--- a/src/app/css/tooltip.css
+++ b/src/app/css/tooltip.css
@@ -1,0 +1,21 @@
+@import "theming.css";
+
+#tooltip {
+	color: white;
+	opacity: 0.0;
+	position: fixed;
+	font-weight: 600;
+	font-size: 0.8em;
+	width: max-content;
+	z-index: 99999999999;
+	pointer-events: none;
+	background: var(--bg);
+	backdrop-filter: blur(15px);
+	transition: opacity 0.15s ease-in-out;
+	border-radius: calc(var(--padding) / 1);
+	padding: calc(var(--padding) / 2.8) calc(var(--padding) / 1.8);
+}
+
+#tooltip.visible {
+	opacity: 1.0;
+}

--- a/src/app/index.html
+++ b/src/app/index.html
@@ -12,9 +12,15 @@
 		<div id="toasts"></div>
 
 		<div id="winbtns">
-			<div id="settings" tooltip="%%tooltip.settings%%" onclick="Settings.toggle(true)"></div>
-			<div id="minimize" tooltip="%%tooltip.minimize%%" onclick="ipcRenderer.send('minimize')"></div>
-			<div id="close" tooltip="%%tooltip.close%%" onclick="ipcRenderer.send('exit')"></div>
+			<div id="settings" tooltip="%%tooltip.settings%%" onclick="Settings.toggle(true)">
+				<img src="icons/settings.png">
+			</div>
+			<div id="minimize" tooltip="%%tooltip.minimize%%" onclick="ipcRenderer.send('minimize')">
+				<img src="icons/minimize.png">
+			</div>
+			<div id="close" tooltip="%%tooltip.close%%" onclick="ipcRenderer.send('exit')">
+				<img src="icons/close.png">
+			</div>
 		</div>
 
 		<div id="dragUI">

--- a/src/app/index.html
+++ b/src/app/index.html
@@ -6,13 +6,15 @@
 		<meta charset="utf-8">
 	</head>
 	<body>
+		<div id="tooltip">Test</div>
+
 		<div id="bgHolder"></div>
 		<div id="toasts"></div>
 
 		<div id="winbtns">
-			<div id="settings" onclick="Settings.toggle(true)"></div>
-			<div id="minimize" onclick="ipcRenderer.send('minimize')"></div>
-			<div id="close" onclick="ipcRenderer.send('exit')"></div>
+			<div id="settings" tooltip="%%tooltip.settings%%" onclick="Settings.toggle(true)"></div>
+			<div id="minimize" tooltip="%%tooltip.minimize%%" onclick="ipcRenderer.send('minimize')"></div>
+			<div id="close" tooltip="%%tooltip.close%%" onclick="ipcRenderer.send('exit')"></div>
 		</div>
 
 		<div id="dragUI">
@@ -170,9 +172,9 @@
 		</div>
 		
 		<nav class="gamesContainer">
-			<button id="vpBtn" onclick="page(0)"></button>
-			<button id="nsBtn" onclick="page(1)"></button>
-			<button id="tfBtn" onclick="page(2)"></button>
+			<button id="vpBtn" tooltip="%%tooltip.pages.viper%%" tooltip-position="horizontal" onclick="page(0)"></button>
+			<button id="nsBtn" tooltip="%%tooltip.pages.northstar%%" tooltip-position="horizontal" onclick="page(1)"></button>
+			<button id="tfBtn" tooltip="%%tooltip.pages.titanfall%%" tooltip-position="horizontal" onclick="page(2)"></button>
 		</nav>
 
 		<div class="mainContainer">
@@ -261,6 +263,7 @@
 		<script src="js/misc.js"></script>
 		<script src="js/mods.js"></script>
 		<script src="js/toast.js"></script>
+		<script src="js/tooltip.js"></script>
 		<script src="js/browser.js"></script>
 		<script src="js/settings.js"></script>
 		<script src="js/launcher.js"></script>

--- a/src/app/js/browser.js
+++ b/src/app/js/browser.js
@@ -115,7 +115,11 @@ var Browser = {
 		return installFromURL(
 			package_obj.download || package_obj.versions[0].download_url,
 			package_obj.dependencies || package_obj.versions[0].dependencies,
-			clear_queue, package_obj.owner
+			clear_queue,
+
+			package_obj.author || package_obj.owner,
+			package_obj.name || package_obj.pkg.name,
+			package_obj.version || package_obj.versions[0].version_number
 		)
 	},
 	add_pkg_properties: () => {
@@ -463,7 +467,7 @@ ipcRenderer.on("failed-mod", (event, modname) => {
 	})
 })
 
-ipcRenderer.on("duped-mod", (event, modname) => {
+ipcRenderer.on("legacy-duped-mod", (event, modname) => {
 	if (recent_toasts["duped" + modname]) {return}
 	add_recent_toast("duped" + modname);
 
@@ -490,28 +494,30 @@ ipcRenderer.on("installed-mod", (event, mod) => {
 	if (recent_toasts["installed" + mod.name]) {return}
 	add_recent_toast("installed" + mod.name);
 
+	let name = mod.fancy_name || mod.name;
+
 	setButtons(true);
-	Browser.setbutton(mod.name, lang("gui.browser.reinstall"));
+	Browser.setbutton(name, lang("gui.browser.reinstall"));
 
 	if (mod.malformed) {
 		new Toast({
 			timeout: 8000,
 			scheme: "warning",
 			title: lang("gui.toast.title.malformed"),
-			description: mod.name + " " + lang("gui.toast.desc.malformed")
+			description: name + " " + lang("gui.toast.desc.malformed")
 		})
 	}
 
 	new Toast({
 		scheme: "success",
 		title: lang("gui.toast.title.installed"),
-		description: mod.name + " " + lang("gui.toast.desc.installed")
+		description: name + " " + lang("gui.toast.desc.installed")
 	})
 
 	if (installqueue.length != 0) {
 		installFromURL(
 			"https://thunderstore.io/package/download/" + installqueue[0].pkg,
-			false, false, installqueue[0].author
+			false, false, installqueue[0].author, installqueue[0].package_name, installqueue[0].version
 		)
 
 		installqueue.shift();

--- a/src/app/js/browser.js
+++ b/src/app/js/browser.js
@@ -111,7 +111,6 @@ var Browser = {
 		browser.classList.toggle("shown");
 	},
 	install: (package_obj, clear_queue = false) => {
-		console.log(package_obj)
 		return installFromURL(
 			package_obj.download || package_obj.versions[0].download_url,
 			package_obj.dependencies || package_obj.versions[0].dependencies,

--- a/src/app/js/browser.js
+++ b/src/app/js/browser.js
@@ -133,9 +133,9 @@ var Browser = {
 				for (let ii = 0; ii < modsobj.all.length; ii++) {
 					let mod = modsobj.all[ii];
 
-					if (normalize(mod.Name) === normalized) {
-						local_name = mod.Name;
-						local_version = version.format(mod.Version);
+					if (normalize(mod.name) === normalized) {
+						local_name = mod.name;
+						local_version = version.format(mod.version);
 						if (version.is_newer(remote_version, local_version)) {
 							has_update = true;
 						}
@@ -270,13 +270,13 @@ var Browser = {
 
 			setTimeout(() => {
 				for (let i = 0; i < modsobj.all.length; i++) {
-					let modname = normalize(modsobj.all[i].Name);
-					let modfolder = normalize(modsobj.all[i].FolderName);
+					let modname = normalize(modsobj.all[i].name);
+					let modfolder = normalize(modsobj.all[i].folder_name);
 
 					if (mod.includes(modname)) {
 						if (! make(modname)) {
-							if (modsobj.all[i].ManifestName) {
-								make(normalize(modsobj.all[i].ManifestName));
+							if (modsobj.all[i].manifest_name) {
+								make(normalize(modsobj.all[i].manifest_name));
 							}
 						}
 					}
@@ -386,7 +386,7 @@ function BrowserEl(properties) {
 	let normalized_mods = [];
 
 	for (let i = 0; i < modsobj.all; i++) {
-		normalized_mods.push(normalize(mods_list[i].Name));
+		normalized_mods.push(normalize(mods_list[i].name));
 	}
 
 	if (properties.pkg.local_version) {
@@ -445,8 +445,8 @@ function add_recent_toast(name, timeout = 3000) {
 ipcRenderer.on("removed-mod", (event, mod) => {
 	setButtons(true);
 	Browser.setbutton(mod.name, lang("gui.browser.install"));
-	if (mod.manifestname) {
-		Browser.setbutton(mod.manifestname, lang("gui.browser.install"));
+	if (mod.manifest_name) {
+		Browser.setbutton(mod.manifest_name, lang("gui.browser.install"));
 	}
 })
 

--- a/src/app/js/mods.js
+++ b/src/app/js/mods.js
@@ -69,7 +69,7 @@ mods.load = (mods_obj) => {
 			</div>
 		`;
 
-		div.querySelector(".remove").addEventListener("click", () => {
+		div.querySelector(".remove").onclick = () => {
 			if (! mod.package) {
 				return mods.remove(mod.name);
 			}
@@ -77,7 +77,7 @@ mods.load = (mods_obj) => {
 			for (let i = 0; i < mod.packaged_mods.length; i++) {
 				mods.remove(mod.packaged_mods[i]);
 			}
-		})
+		}
 
 		if (mod.disabled) {
 			div.querySelector(".switch").classList.remove("on");
@@ -123,7 +123,6 @@ mods.load = (mods_obj) => {
 			return;
 		}
 
-
 		let image_container = mod_els[i].querySelector(".image");
 		let image_el = image_container.querySelector("img")
 		let image_blur_el = image_container.querySelector("img.blur")
@@ -157,6 +156,10 @@ mods.load = (mods_obj) => {
 			}
 
 			let mod_el = mod_els[i].cloneNode(true);
+
+			// copy click event of the remove button to the new button
+			mod_el.querySelector(".remove").onclick =
+				mod_els[i].querySelector(".remove").onclick;
 
 			mod_el.classList.add("no-animation");
 

--- a/src/app/js/mods.js
+++ b/src/app/js/mods.js
@@ -6,13 +6,13 @@ mods.load = (mods_obj) => {
 	let normalized_names = [];
 	
 	let set_mod = (mod) => {
-		let normalized_name = "mod-list-" + normalize(mod.Name);
+		let normalized_name = "mod-list-" + normalize(mod.name);
 
 		normalized_names.push(normalized_name);
 
 		let el = document.getElementById(normalized_name);
 		if (el) {
-			if (mod.Disabled) {
+			if (mod.disabled) {
 				el.querySelector(".switch").classList.remove("on");
 			} else {
 				el.querySelector(".switch").classList.add("on");
@@ -31,30 +31,30 @@ mods.load = (mods_obj) => {
 				<img class="blur" src="">
 			</div>
 			<div class="text">
-				<div class="title">${mod.Name}</div>
-				<div class="description">${mod.Description}</div>
+				<div class="title">${mod.name}</div>
+				<div class="description">${mod.description}</div>
 				<button class="switch on orange"></button>
 				<button class="update bg-blue">
 					${lang("gui.browser.update")}
 				</button>
-				<button class="bg-red" onclick="mods.remove('${mod.Name}')">
+				<button class="bg-red" onclick="mods.remove('${mod.name}')">
 					${lang("gui.mods.remove")}
 				</button>
 
-				<button class="visual">${version.format(mod.Version)}</button>
+				<button class="visual">${version.format(mod.version)}</button>
 				<button class="visual">
 					${lang("gui.browser.madeby")}
-					${mod.Author || lang("gui.mods.unknown_author")}
+					${mod.author || lang("gui.mods.unknown_author")}
 				</button>
 			</div>
 		`;
 
-		if (mod.Disabled) {
+		if (mod.disabled) {
 			div.querySelector(".switch").classList.remove("on");
 		}
 
 		div.querySelector(".switch").addEventListener("click", () => {
-			mods.toggle(mod.Name);
+			mods.toggle(mod.name);
 		})
 
 		div.querySelector(".image").style.display = "none";

--- a/src/app/js/tooltip.js
+++ b/src/app/js/tooltip.js
@@ -1,0 +1,130 @@
+var tooltip = {
+	target: false,
+	div: document.getElementById("tooltip"),
+}
+
+tooltip.show = (target, text, vertical_positioned) => {
+	if (target == tooltip.target) {
+		return;
+	}
+
+	tooltip.target = target;
+
+	let div = tooltip.div;
+
+	let padding = parseFloat(
+		getComputedStyle(div).getPropertyValue("padding")
+	);
+
+	let tooltip_padding = padding / 1.2;
+
+	let get_positions = () => {
+		div.innerHTML = text;
+
+		let div_rect = div.getBoundingClientRect();
+		let target_rect = target.getBoundingClientRect();
+
+		let x_pos = 0;
+		let y_pos = 0;
+
+		if (vertical_positioned) {
+			x_pos = target_rect.x + (target_rect.width / 2);
+			x_pos = x_pos - (div_rect.width / 2);
+
+			if (x_pos < padding) {
+				x_pos = padding;
+			} else if (x_pos + div_rect.width > window.innerWidth - padding) {
+				x_pos = window.innerWidth - div_rect.width - padding;
+			}
+
+			y_pos = target_rect.y + target_rect.height + tooltip_padding;
+
+			if (y_pos + div_rect.height > window.innerHeight) {
+				y_pos = target_rect.y - div_rect.height - tooltip_padding;
+			}
+		} else {
+			x_pos = target_rect.x - div_rect.width - tooltip_padding;
+
+			if (x_pos < 0) {
+				x_pos = target_rect.x + target_rect.width + tooltip_padding;
+			}
+
+			if (x_pos > window.innerWidth - padding) {
+				x_pos = window.innerWidth - div_rect.width - padding;
+			}
+
+			y_pos = target_rect.y + (target_rect.height / 2);
+			y_pos = y_pos - (div_rect.height / 2);
+		}
+
+		return {x: x_pos, y: y_pos}
+	}
+
+	let transition_duration = parseFloat(
+		getComputedStyle(div).getPropertyValue("transition-duration")
+	) * 1000;
+
+	if (div.classList.contains("visible")) {
+		div.classList.remove("visible");
+	}
+
+	return new Promise((resolve) => {
+		setTimeout(() => {
+			if (tooltip.target != target) {
+				return resolve();
+			}
+
+			let pos = get_positions();
+			div.style.top = pos.y + "px";
+			div.style.left = pos.x + "px";
+		}, transition_duration)
+
+		setTimeout(() => {
+			if (tooltip.target != target) {
+				return resolve();
+			}
+
+			div.classList.add("visible");
+
+			resolve();
+		}, transition_duration * 2)
+	})
+}
+
+let mouse_y = 0;
+let mouse_x = 0;
+
+let tooltip_event = (event) => {
+	if (event && event.x && event.y) {
+		mouse_y = event.y;
+		mouse_x = event.x;
+	} else {
+		event = {
+			x: mouse_x,
+			y: mouse_y
+		}
+	}
+
+	let at_mouse = document.elementFromPoint(event.x, event.y);
+
+	if (! at_mouse) {return}
+
+	let tooltip_text = at_mouse.getAttribute("tooltip");
+	if (! tooltip_text) {
+		tooltip.target = false;
+		tooltip.div.classList.remove("visible");
+
+		return;
+	}
+
+	let position = at_mouse.getAttribute("tooltip-position") || "vertical";
+	tooltip.show(at_mouse, tooltip_text, (position == "vertical"));
+}
+
+setInterval(tooltip_event, 1000);
+document.addEventListener("click", tooltip_event);
+document.addEventListener("mouseup", tooltip_event);
+document.addEventListener("mousedown", tooltip_event);
+document.addEventListener("mousemove", tooltip_event);
+document.addEventListener("mouseenter", tooltip_event);
+document.addEventListener("mouseleave", tooltip_event);

--- a/src/app/main.css
+++ b/src/app/main.css
@@ -2,6 +2,7 @@
 @import "css/dragui.css";
 @import "css/toasts.css";
 @import "css/popups.css";
+@import "css/tooltip.css";
 @import "css/theming.css";
 @import "css/launcher.css";
 

--- a/src/app/main.css
+++ b/src/app/main.css
@@ -57,11 +57,13 @@ button:active {filter: brightness(90%)}
 	margin-right: calc(var(--padding) / 2);
 }
 
-#winbtns #close {background-image: url("icons/close.png")}
-#winbtns #minimize {background-image: url("icons/minimize.png")}
-#winbtns #settings {background-image: url("icons/settings.png")}
+#winbtns div img {
+	width: 100%;
+	height: 100%;
+	transition: transform 0.25s ease-in-out;
+}
 
-#winbtns #settings:hover {
+#winbtns #settings:hover img {
 	transform: rotate(90deg);
 }
 

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -173,7 +173,7 @@ function installFromPath(path) {
 }
 
 // Tells the main process to install a mod from a URL
-function installFromURL(url, dependencies, clearqueue, author) {
+function installFromURL(url, dependencies, clearqueue, author, package_name, version) {
 	if (clearqueue) {installqueue = []};
 
 	let prettydepends = [];
@@ -188,7 +188,9 @@ function installFromURL(url, dependencies, clearqueue, author) {
 				if (! isModInstalled(pkg[1])) {
 					newdepends.push({
 						pkg: depend,
-						author: pkg[0]
+						author: pkg[0],
+						version: pkg[2],
+						package_name: pkg[1]
 					});
 
 					prettydepends.push(`${pkg[1]} v${pkg[2]} - ${lang("gui.browser.madeby")} ${pkg[0]}`);
@@ -207,7 +209,7 @@ function installFromURL(url, dependencies, clearqueue, author) {
 	}
 
 	setButtons(false);
-	ipcRenderer.send("install-from-url", url, author);
+	ipcRenderer.send("install-from-url", url, author, package_name, version);
 
 	if (dependencies) {
 		installqueue = dependencies;

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -242,6 +242,31 @@ ipcRenderer.on("confirm", (event, data) => {
 	ipcRenderer.send("confirm-closed-" + data.id, confirmed);
 })
 
+let is_running = false;
+ipcRenderer.on("is-running", (event, running) => {
+	let set_playbtns = (text) => {
+		let playbtns = document.querySelectorAll(".playBtn");
+		for (let i = 0; i < playbtns.length; i++) {
+			playbtns[i].innerHTML = text;
+		}
+	}
+
+	if (running && is_running != running) {
+		setButtons(false);
+		set_playbtns(lang("general.running"));
+
+		is_running = running;
+		return;
+	}
+
+	if (is_running != running) {
+		setButtons(true);
+		set_playbtns(lang("gui.launch"));
+
+		is_running = running;
+	}
+})
+
 // Updates the installed mods
 ipcRenderer.on("mods", (event, mods_obj) => {
 	modsobj = mods_obj;

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -3,7 +3,12 @@ const path = require("path");
 const { app, ipcRenderer, shell } = require("electron");
 
 const lang = require("../lang");
-var modsobj = {};
+var modsobj = {
+	all: [],
+	enabled: [],
+	disabled: []
+}
+
 let shouldInstallNorthstar = false;
 
 // Base settings
@@ -212,11 +217,11 @@ function installFromURL(url, dependencies, clearqueue, author) {
 function isModInstalled(modname) {
 	for (let i = 0; i < modsobj.all.length; i++) {
 		let mod = modsobj.all[i];
-		if (mod.ManifestName) {
-			if (mod.ManifestName.match(modname)) {
+		if (mod.manifest_name) {
+			if (mod.manifest_name.match(modname)) {
 				return true;
 			}
-		} else if (mod.Name.match(modname)) {
+		} else if (mod.name.match(modname)) {
 			return true;
 		}
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -19,9 +19,9 @@ const version = require("./modules/version");
 const gamepath = require("./modules/gamepath");
 const settings = require("./modules/settings");
 const requests = require("./modules/requests");
+const packages = require("./modules/packages");
 const is_running = require("./modules/is_running");
 
-const plugins = require("./modules/packages");
 
 var log = console.log;
 
@@ -113,7 +113,9 @@ function start() {
 
 	// install calls
 	ipcMain.on("install-from-path", (event, path) => {mods.install(path)});
-	ipcMain.on("install-from-url", (event, url, author) => {mods.installFromURL(url, author)});
+	ipcMain.on("install-from-url", (event, url, author, package_name, version) => {
+		packages.install(url, author, package_name, version);
+	});
 
 	win.webContents.on("dom-ready", () => {
 		send("mods", mods.list());

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,8 @@ const settings = require("./modules/settings");
 const requests = require("./modules/requests");
 const is_running = require("./modules/is_running");
 
+const plugins = require("./modules/packages");
+
 var log = console.log;
 
 // Starts the actual BrowserWindow, which is only run when using the

--- a/src/index.js
+++ b/src/index.js
@@ -156,6 +156,10 @@ function start() {
 	ipcMain.on("update-now", () => {
 		autoUpdater.quitAndInstall();
 	})
+
+	setInterval(async () => {
+		send("is-running", await is_running.game());
+	}, 1000)
 }
 
 ipcMain.on("install-mod", () => {

--- a/src/index.js
+++ b/src/index.js
@@ -239,13 +239,13 @@ ipcMain.on("getmods", () => {
 		log(`${lang("general.mods.installed")} ${mods.all.length}`);
 		log(`${lang("general.mods.enabled")} ${mods.enabled.length}`);
 		for (let i = 0; i < mods.enabled.length; i++) {
-			log(`  ${mods.enabled[i].Name} ${mods.enabled[i].Version}`);
+			log(`  ${mods.enabled[i].name} ${mods.enabled[i].version}`);
 		}
 
 		if (mods.disabled.length > 0) {
 			log(`${lang("general.mods.disabled")} ${mods.disabled.length}`);
 			for (let i = 0; i < mods.disabled.length; i++) {
-				log(`  ${mods.disabled[i].Name} ${mods.disabled[i].Version}`);
+				log(`  ${mods.disabled[i].name} ${mods.disabled[i].version}`);
 			}
 		}
 		cli.exit(0);

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -169,5 +169,12 @@
 	"general.invalidconfig": "Your config file is improperly formatted, if it's been manually edited, please validate that everything is typed correctly.\n\nIf you did not manually edit the config file, it is recommended to simply reset the config.\n\nTo reset your config file simply click \"Ok\" below.\n\nMore details:\n",
 
 	"request.viper.noReleaseNotes": "Couldn't fetch Viper release notes.\nTry again later!",
-	"request.northstar.noReleaseNotes": "Couldn't fetch Northstar release notes.\nTry again later!"
+	"request.northstar.noReleaseNotes": "Couldn't fetch Northstar release notes.\nTry again later!",
+
+	"tooltip.close": "Closes Viper",
+	"tooltip.minimize": "Minimizes the window",
+	"tooltip.settings": "Opens the settings popup",
+	"tooltip.pages.viper": "Viper",
+	"tooltip.pages.northstar": "Northstar",
+	"tooltip.pages.titanfall": "Titanfall 2"
 }

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -69,6 +69,8 @@
 	"gui.mods.installedmod": "Installed mod!",
 	"gui.mods.dragdrop": "Drag and drop a mod to install",
 	"gui.mods.confirmdependencies": "This package has dependencies, shown below, clicking \"Ok\" will install the package and the dependencies.\n\n",
+	"gui.mods.confirm_plugins_title": "The following package has native plugins:",
+	"gui.mods.confirm_plugins_description": "Native plugins have far more system access than a regular mod, and because of this they're inherently less secure to have installed, as a malicious plugin could do far more harm this way. If this plugin is one from a trusted developer or similar or you know what you're doing, then you can disregard this message completely.",
 
 	"gui.browser.info": "Info",
 	"gui.browser.view": "View",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -164,6 +164,7 @@
 	"general.mods.installed": "Installed mods:",
 	"general.missingpath": "Game location could not be found automatically! Please select it manually!",
 	"general.notinstalled": "Northstar is not installed!",
+	"general.running": "Running",
 	"general.launching": "Launching",
 	"general.invalidconfig": "Your config file is improperly formatted, if it's been manually edited, please validate that everything is typed correctly.\n\nIf you did not manually edit the config file, it is recommended to simply reset the config.\n\nTo reset your config file simply click \"Ok\" below.\n\nMore details:\n",
 

--- a/src/modules/mods.js
+++ b/src/modules/mods.js
@@ -602,7 +602,7 @@ mods.remove = (mod) => {
 	// if the mod has a manifest.json we want to save it now so we can
 	// send it later when telling the renderer about the deleted mod
 	if (fs.existsSync(path.join(mod_path, "manifest.json"))) {
-		manifest_name = require(path.join(mod_path, "manifest.json")).name;
+		manifest_name = json(path.join(mod_path, "manifest.json")).name;
 	}
 
 	// actually remove the mod itself

--- a/src/modules/mods.js
+++ b/src/modules/mods.js
@@ -54,7 +54,9 @@ mods.list = () => {
 	}
 
 	let get_in_dir = (dir, package_obj) => {
+		let packaged_mods = [];
 		let files = fs.readdirSync(dir);
+
 		files.forEach((file) => {
 			// return early if `file` isn't a folder
 			if (! fs.statSync(path.join(dir, file)).isDirectory()) {
@@ -84,6 +86,7 @@ mods.list = () => {
 			}
 
 			if (obj.package) {
+				packaged_mods.push(obj.name);
 				obj.author = obj.package.author;
 			}
 
@@ -114,6 +117,27 @@ mods.list = () => {
 				enabled.push(obj);
 			}
 		})
+
+		if (packaged_mods.length == 0) {
+			return;
+		}
+
+		let add_packaged_mods = (mods_array) => {
+			for (let i = 0; i < mods_array.length; i++) {
+				if (mods_array[i].package.package_name !==
+					package_obj.package_name) {
+
+					continue;
+				}
+
+				mods_array[i].packaged_mods = packaged_mods;
+			}
+
+			return mods_array;
+		}
+
+		enabled = add_packaged_mods(enabled);
+		disbled = add_packaged_mods(disabled);
 	}
 
 	// get mods in `mods` folder

--- a/src/modules/mods.js
+++ b/src/modules/mods.js
@@ -72,14 +72,15 @@ mods.list = () => {
 			if (! mod) {return}
 
 			let obj = {
-				Author: mod.Author || false,
-				Version: mod.Version || "unknown",
-				Name: mod.Name || "unknown",
-				Description: mod.Description || "",
+				author: mod.Author || false,
+				version: mod.Version || "unknown",
+				name: mod.Name || "unknown",
+				description: mod.Description || "",
 
-				FolderName: file,
-				FolderPath: path.join(dir, file),
-				Package: package_obj || false
+				folder_name: file,
+				folder_path: path.join(dir, file),
+
+				package: package_obj || false
 			}
 
 			// Electron's serializer for
@@ -105,20 +106,20 @@ mods.list = () => {
 			obj = JSON.stringify(obj);
 			obj = JSON.parse(obj);
 
-			if (obj.Package) {
-				obj.Author = obj.Package.author;
+			if (obj.package) {
+				obj.author = obj.package.author;
 			}
 
-			obj.Disabled = ! mods.modfile.get(obj.Name);
+			obj.disabled = ! mods.modfile.get(obj.name);
 
 			// add manifest data from manifest.json, if it exists
 			let manifest_file = path.join(dir, file, "manifest.json");
 			if (fs.existsSync(manifest_file)) {
 				let manifest = json(manifest_file);
 				if (manifest != false) {
-					obj.ManifestName = manifest.name;
-					if (obj.Version == "unknown") {
-						obj.Version = manifest.version_number;
+					obj.manifest_name = manifest.name;
+					if (obj.version == "unknown") {
+						obj.version = manifest.version_number;
 					}
 				}
 			}
@@ -126,11 +127,11 @@ mods.list = () => {
 			// add author data from author file, if it exists
 			let author_file = path.join(dir, file, "thunderstore_author.txt");
 			if (fs.existsSync(author_file)) {
-				obj.Author = fs.readFileSync(author_file, "utf8");
+				obj.author = fs.readFileSync(author_file, "utf8");
 			}
 
 			// add mod to their respective disabled or enabled Array
-			if (obj.Disabled) {
+			if (obj.disabled) {
 				disabled.push(obj);
 			} else {
 				enabled.push(obj);
@@ -185,7 +186,7 @@ mods.get = (mod) => {
 
 	// search for mod in list
 	for (let i = 0; i < list.length; i++) {
-		if (list[i].Name == mod) {
+		if (list[i].name == mod) {
 			// found mod, return data
 			return list[i];
 		} else {continue}
@@ -225,7 +226,7 @@ mods.modfile.gen = () => {
 	let list = mods.list().all; // get list of all mods
 	for (let i = 0; i < list.length; i++) {
 		// add every mod to the list
-		names[list[i].Name] = true
+		names[list[i].name] = true
 	}
 
 	// write the actual file
@@ -565,12 +566,12 @@ mods.remove = (mod) => {
 	if (mod == "allmods") {
 		let modlist = mods.list().all;
 		for (let i = 0; i < modlist.length; i++) {
-			mods.remove(modlist[i].Name);
+			mods.remove(modlist[i].name);
 		}
 		return
 	}
 
-	let mod_name = mods.get(mod).FolderName;
+	let mod_name = mods.get(mod).folder_name;
 	if (! mod_name) {
 		console.log("error: " + lang("cli.mods.cantfind"));
 		cli.exit(1);
@@ -584,12 +585,12 @@ mods.remove = (mod) => {
 		return cli.exit(1);
 	}
 
-	let manifestname = null;
+	let manifest_name = null;
 
 	// if the mod has a manifest.json we want to save it now so we can
 	// send it later when telling the renderer about the deleted mod
 	if (fs.existsSync(path.join(path_to_mod, "manifest.json"))) {
-		manifestname = require(path.join(path_to_mod, "manifest.json")).name;
+		manifest_name = require(path.join(path_to_mod, "manifest.json")).name;
 	}
 
 	// actually remove the mod itself
@@ -604,7 +605,7 @@ mods.remove = (mod) => {
 	// relevant info for it to properly update everything graphically
 	ipcMain.emit("removed-mod", "", {
 		name: mod.replace(/^.*(\\|\/|\:)/, ""),
-		manifestname: manifestname
+		manifest_name: manifest_name
 	});
 }
 
@@ -629,7 +630,7 @@ mods.toggle = (mod, fork) => {
 	if (mod == "allmods") {
 		let modlist = mods.list().all; // get list of all mods
 		for (let i = 0; i < modlist.length; i++) { // run through list
-			mods.toggle(modlist[i].Name, true); // enable mod
+			mods.toggle(modlist[i].name, true); // enable mod
 		}
 
 		console.log(lang("cli.mods.toggledall"));

--- a/src/modules/packages.js
+++ b/src/modules/packages.js
@@ -1,7 +1,7 @@
 const path = require("path");
 const fs = require("fs-extra");
 const unzip = require("unzipper");
-const app = require("electron").app;
+const { app, ipcMain } = require("electron");
 const https = require("follow-redirects").https;
 
 const json = require("./json");
@@ -203,6 +203,8 @@ packages.install = async (url, author, package_name, version) => {
 			}
 			break;
 		default:
+			ipcMain.emit("failed-mod", name);
+
 			// other unhandled error
 			return console.log(
 				"Verification of package failed:", name,
@@ -233,9 +235,15 @@ packages.install = async (url, author, package_name, version) => {
 	let moved = packages.move(package_path);
 
 	if (! moved) {
+		ipcMain.emit("failed-mod", name);
 		console.log("Moving package failed:", name);
 		return false;
 	}
+
+	ipcMain.emit("installed-mod", "", {
+		name: name,
+		fancy_name: package_name
+	})
 
 	console.log("Installed package:", name);
 	return true;

--- a/src/modules/packages.js
+++ b/src/modules/packages.js
@@ -1,0 +1,338 @@
+const path = require("path");
+const fs = require("fs-extra");
+const unzip = require("unzipper");
+const app = require("electron").app;
+const https = require("follow-redirects").https;
+
+const json = require("./json");
+const win = require("./window");
+const settings = require("./settings");
+
+var packages = {};
+
+function update_path() {
+	packages.path = path.join(settings.gamepath, "R2Northstar/packages");
+	
+	// make sure the `packages` folder exists
+	if (fs.existsSync(packages.path)) {
+		// if it does, but it's a file, remove it
+		if (fs.lstatSync(packages.path).isFile()) {
+			fs.rmSync(packages.path);
+		} else {return}
+	} 
+
+	// create the folder, in case it doesn't already exist
+	fs.mkdirSync(packages.path);
+}; update_path();
+
+packages.format_name = (author, package_name, version) => {
+	return author + "-" + package_name + "-" + version;
+}
+
+// splits the package name into it's individual parts
+packages.split_name = (name) => {
+	let split = name.split("-");
+
+	// make sure there are only 3 parts
+	if (split.length !== 3) {
+		return false;
+	}
+
+	// return parts
+	return {
+		author: split[0],
+		version: split[2],
+		package_name: split[1]
+	}
+}
+
+packages.list = (dir = packages.path) => {
+	let files = fs.readdirSync(dir);
+	let package_list = {};
+
+	for (let i = 0; i < files.length; i++) {
+		let package_path = path.join(dir, files[i]);
+		let verification = packages.verify(package_path);
+
+		let split_name = packages.split_name(files[i]);
+
+		if (! split_name) {continue}
+
+		// make sure the package is actually package
+		switch(verification) {
+			case true:
+			case "has-plugins":
+				package_list[files[i]] = {
+					// adds `author`, `package_name` and `version`
+					...split_name,
+
+					icon: false, // will be set later
+					package_path: package_path, // path to package
+
+					// this is whether or not the package has plugins
+					has_plugins: (verification == "has-plugins"),
+
+					// contents of `manifest.json` or `false` if it can
+					// be parsed correctly
+					manifest: json(
+						path.join(package_path, "manifest.json")
+					),
+				}
+
+				// add `.remove()` function, mostly just a shorthand
+				package_list[files[i]].remove = () => {
+					return packages.remove(
+						split_name.author,
+						split_name.package_name,
+						split_name.version,
+					)
+				}
+
+				// set the `.icon` property
+				let icon_file = path.join(package_path, "icon.png");
+				if (fs.existsSync(icon_file) &&
+					fs.lstatSync(icon_file).isFile()) {
+
+					package_list[files[i]].icon = icon_file;
+				}
+				break;
+		}
+	}
+
+	return package_list;
+}
+
+packages.remove = (author, package_name, version) => {
+	// if `version` is not set, we'll search for a package with the same
+	// `author` and `package_name` and use the version from that,
+	// this'll be useful when updating, of course this assumes that
+	// nobody has two versions of the same package installed
+	//
+	// TODO: perhaps we should remove duplicate packages?
+	if (! version) {
+		// get list of packages
+		let list = packages.list();
+
+		// iterate through them
+		for (let i in list) {
+			// check for `author` and `package_name` being the same
+			if (list[i].author == author &&
+				list[i].package_name == package_name) {
+
+				// set `version` to the found package
+				version = list[i].version;
+				break;
+			}
+		}
+	}
+
+	let name = packages.format_name(author, package_name, version);
+	let package_path = path.join(packages.path, name);
+	
+	// make sure the package even exists to begin with
+	if (! fs.existsSync(package_path)) {
+		return false;
+	}
+
+	fs.rmSync(package_path, {recursive: true});
+
+	// return the inverse of whether the package still exists, this'll
+	// be equivalent to whether or not the removal was successful
+	return !! fs.existsSync(package_path);
+}
+
+packages.install = async (url, author, package_name, version) => {
+	update_path();
+
+	let name = packages.format_name(author, package_name, version);
+
+	console.log("Downloading package:", name);
+	// download `url` to a temporary dir, and return the path to it
+	let zip_path = await packages.download(url, name);
+
+	console.log("Extracting package:", name);
+	// extract the zip file we downloaded before, and return the path of
+	// the folder that we extracted it to
+	let package_path = await packages.extract(zip_path, name);
+
+
+	console.log("Verifying package:", name);
+	let verification = packages.verify(package_path);
+
+	switch(verification) {
+		case "has-plugins":
+			// if the package has plugins, then we want to prompt the
+			// user, and make absolutely certain that they do want to
+			// install this package, as plugins have security concerns
+			let confirmation = await win.confirm(
+				`The following package has native plugins: ${name} \n\n`
+
+				+
+
+				"Native plugins have far more system access than a " +
+				"regular mod, and because of this they're inherently " +
+				"less secure to have installed, as a malicious plugin" +
+				" could do far more harm this way. If this plugin is " +
+				"one from a trusted developer or similar or you know " +
+				"what you're doing, then you can disregard this " +
+				"message completely."
+			)
+
+			// check whether the user cancelled or confirmed the
+			// installation, and act accordingly
+			if (! confirmation) {
+				return console.log("Cancelled package installation:", name);
+			}
+			break;
+		default:
+			// other unhandled error
+			return console.log(
+				"Verification of package failed:", name,
+				", reason:", verification
+			);
+	}
+
+	console.log("Verified package:", name);
+
+	console.log("Deleting older version, if it exists:", name);
+	packages.remove(author, package_name, version);
+
+	console.log("Moving package:", name);
+	let moved = packages.move(package_path);
+
+	if (moved) {
+		console.log("Installed package:", name);
+	} else {
+		console.log("Moving package failed:", name);
+	}
+}
+
+packages.download = async (url, name) => {
+	update_path();
+
+	return new Promise((resolve) => {
+		// download mod to a temporary location
+		https.get(url, (res) => {
+			let tmp = path.join(app.getPath("cache"), "vipertmp");
+
+			let zip_name = name || "package";
+			let zip_path = path.join(tmp, `/${zip_name}.zip`);
+
+			// make sure the temporary folder exists
+			if (fs.existsSync(tmp)) {
+				// if it's not a folder, then delete it
+				if (! fs.statSync(tmp).isDirectory()) {
+					fs.rmSync(tmp);
+				}
+			} else {
+				// create the folder
+				fs.mkdirSync(tmp);
+
+				// if there's already a zip file at `zip_path`, then we
+				// simple remove it, otherwise problems will occur
+				if (fs.existsSync(zip_path)) {
+					fs.rmSync(zip_path);
+				}
+			}
+
+			// write out the file to the temporary location
+			let stream = fs.createWriteStream(zip_path);
+			res.pipe(stream);
+
+			stream.on("finish", () => {
+				stream.close();
+
+				// return the path of the downloaded zip file
+				resolve(zip_path);
+			})
+		})
+	})
+}
+
+packages.extract = async (zip_path, name) => {
+	// this is where everything from `zip_path` will be extracted
+	let extract_dir = path.join(path.dirname(zip_path), name);
+
+	// delete `extract_dir` if it does exist
+	if (fs.existsSync(extract_dir)) {
+		fs.rmSync(extract_dir, {recursive: true});
+	}
+
+	// make an empty folder at `extract_dir`
+	fs.mkdirSync(extract_dir);
+
+	return new Promise((resolve) => {
+		fs.createReadStream(zip_path).pipe(
+			unzip.Extract({
+				path: extract_dir
+			}
+		)).on("finish", () => {
+			resolve(extract_dir);
+		});
+	})
+}
+
+packages.verify = (package_path) => {
+	// make sure `package_path` is even exists
+	if (! fs.existsSync(package_path)) {
+		return "does-not-exist";
+	}
+
+	// make sure `package_path` is not a folder
+	if (fs.lstatSync(package_path).isFile()) {
+		return "is-file";
+	}
+
+	// make sure a manifest file exists, this is required for
+	// Thunderstore packages, and is therefore also assumed to be
+	// required here
+	let manifest = path.join(package_path, "manifest.json");
+	if (! fs.existsSync(manifest) ||
+		fs.lstatSync(manifest).isDirectory()) {
+
+		return "missing-manifest";
+	}
+
+	// check if there are any plugins in the package
+	let mods = path.join(package_path, "mods");
+	let plugins = path.join(package_path, "plugins");
+	if (fs.existsSync(plugins) && fs.lstatSync(plugins).isDirectory()) {
+		// package has plugins, the function calling `packages.verify()`
+		// will have to handle this at their own discretion
+		return "has-plugins";
+	} else if (! fs.existsSync(mods) || fs.lstatSync(mods).isFile()) {
+		// if there are no plugins, then we check if there are any mods,
+		// if not, then it means there are both no plugins and mods, so
+		// we signal that back
+		return "no-mods";
+	}
+
+	// all files exist, and everything is just fine
+	return true;
+}
+
+// moves `package_path` to the packages folder
+packages.move = (package_path) => {
+	update_path();
+
+	// make sure we're actually dealing with a real folder
+	if (! fs.existsSync(package_path) ||
+		! fs.lstatSync(package_path).isDirectory()) {
+
+		return false;
+	}
+
+	// get path to the package's destination
+	let new_path = path.join(
+		packages.path, path.basename(package_path)
+	)
+
+	// attempt to move `package_path` to the packages folder
+	try {
+		fs.moveSync(package_path, new_path);
+	}catch(err) {return false}
+
+	return true;
+}
+
+module.exports = packages;

--- a/src/modules/packages.js
+++ b/src/modules/packages.js
@@ -368,6 +368,32 @@ packages.verify = (package_path) => {
 		return "no-mods";
 	}
 
+	// make sure files in the `mods` folder actually are mods, and if
+	// none of them are, then we make sure to return back that are no
+	// mods installed
+	let found_mod = false;
+	let mods = fs.readdirSync(mods_path);
+	for (let i = 0; i < mods.length; i++) {
+		let mod = mods[i];
+		let mod_file = path.join(mod, "mod.json");
+
+		// make sure mod.json exists, and is a file, otherwise, this
+		// is unlikely to be a mod folder
+		if (! fs.existsSync(mod_file)
+			|| ! fs.statSync(mod_file).isFile()) {
+			continue;
+		}
+
+		// attempt to read the mod.json file, and if it succeeds, then
+		// this is likely to be a mod
+		let json_data = json(mod_file);
+		if (json_data) {
+			found_mod = true;
+		}
+	}
+
+	if (! found_mod) {return "no-mods"}
+
 	// all files exist, and everything is just fine
 	return true;
 }

--- a/src/modules/packages.js
+++ b/src/modules/packages.js
@@ -165,6 +165,22 @@ packages.install = async (url, author, package_name, version) => {
 
 	let name = packages.format_name(author, package_name, version);
 
+	// removes zip's and folders
+	let cleanup = () => {
+		console.info("Cleaning up cache folder of mod:", name);
+		if (zip_path && fs.existsSync(zip_path)) {
+			fs.rm(zip_path, {recursive: true});
+			console.ok("Cleaned archive of mod:", name);
+		}
+
+		if (package_path && fs.existsSync(package_path)) {
+			fs.rm(zip_path, {recursive: true});
+			console.ok("Cleaned mod folder:", name);
+		}
+
+		console.ok("Cleaned up cache folder of mod:", name);
+	}
+
 	console.info("Downloading package:", name);
 	// download `url` to a temporary dir, and return the path to it
 	let zip_path = await packages.download(url, name);
@@ -199,10 +215,12 @@ packages.install = async (url, author, package_name, version) => {
 			ipcMain.emit("failed-mod", name);
 
 			// other unhandled error
-			return console.error(
+			console.error(
 				"Verification of package failed:", name,
 				", reason:", verification
 			);
+
+			return cleanup();
 	}
 
 	console.ok("Verified package:", name);
@@ -230,6 +248,9 @@ packages.install = async (url, author, package_name, version) => {
 	if (! moved) {
 		ipcMain.emit("failed-mod", name);
 		console.error("Moving package failed:", name);
+
+		cleanup();
+
 		return false;
 	}
 
@@ -239,6 +260,8 @@ packages.install = async (url, author, package_name, version) => {
 	})
 
 	console.ok("Installed package:", name);
+	cleanup();
+
 	return true;
 }
 

--- a/src/modules/packages.js
+++ b/src/modules/packages.js
@@ -217,8 +217,8 @@ packages.install = async (url, author, package_name, version) => {
 	for (let i = 0; i < mods_list.length; i++) {
 		let mod = mods_list[i];
 
-		if (mod.ManifestName == package_name) {
-			mods.remove(mod.Name);
+		if (mod.manifest_name == package_name) {
+			mods.remove(mod.name);
 			continue;
 		}
 	}

--- a/src/modules/packages.js
+++ b/src/modules/packages.js
@@ -4,6 +4,7 @@ const unzip = require("unzipper");
 const app = require("electron").app;
 const https = require("follow-redirects").https;
 
+const mods = require("./mods");
 const json = require("./json");
 const win = require("./window");
 const settings = require("./settings");
@@ -195,7 +196,19 @@ packages.install = async (url, author, package_name, version) => {
 
 	console.log("Verified package:", name);
 
-	console.log("Deleting older version, if it exists:", name);
+	console.log("Deleting older version(s), if it exists:", name);
+	// check and delete any mod with the name package details in the old
+	// `mods` folder, if there are any at all
+	let mods_list = mods.list().all;
+	for (let i = 0; i < mods_list.length; i++) {
+		let mod = mods_list[i];
+
+		if (mod.ManifestName == package_name) {
+			mods.remove(mod.Name);
+			continue;
+		}
+	}
+
 	packages.remove(author, package_name, version);
 
 	console.log("Moving package:", name);
@@ -217,7 +230,7 @@ packages.download = async (url, name) => {
 			let tmp = path.join(app.getPath("cache"), "vipertmp");
 
 			let zip_name = name || "package";
-			let zip_path = path.join(tmp, `/${zip_name}.zip`);
+			let zip_path = path.join(tmp, `${zip_name}.zip`);
 
 			// make sure the temporary folder exists
 			if (fs.existsSync(tmp)) {

--- a/src/modules/packages.js
+++ b/src/modules/packages.js
@@ -240,6 +240,7 @@ packages.install = async (url, author, package_name, version) => {
 	}
 
 	// removes older version of package inside the `packages` folder
+	packages.remove(author, package_name);
 	packages.remove(author, package_name, version);
 
 	console.info("Moving package:", name);

--- a/src/modules/packages.js
+++ b/src/modules/packages.js
@@ -237,6 +237,36 @@ packages.install = async (url, author, package_name, version) => {
 			mods.remove(mod.name);
 			continue;
 		}
+
+		// normalizes a string, i.e attempt to make two strings
+		// identical, that simply have slightly different formatting, as
+		// an example, these strings:
+		//
+		//   "Mod_Name" and "Mod name"
+		//
+		// will just become:
+		//
+		//   "modname"
+		let normalize = (string) => {
+			return string.toLowerCase()
+				.replaceAll("_", "")
+				.replaceAll(".", "")
+				.replaceAll(" ", "");
+		}
+
+		// check if the mod's name from it's `mod.json` file when
+		// normalized, is the same as the normalized name of the package
+		if (normalize(mod.name) == normalize(package_name)) {
+			mods.remove(mod.name);
+			continue;
+		}
+
+		// check if the name of the mod's folder when normalized, is the
+		// same as the normalized name of the package
+		if (normalize(mod.folder_name) == normalize(package_name)) {
+			mods.remove(mod.name);
+			continue;
+		}
 	}
 
 	// removes older version of package inside the `packages` folder
@@ -374,8 +404,7 @@ packages.verify = (package_path) => {
 	let found_mod = false;
 	let mods = fs.readdirSync(mods_path);
 	for (let i = 0; i < mods.length; i++) {
-		let mod = mods[i];
-		let mod_file = path.join(mod, "mod.json");
+		let mod_file = path.join(mods_path, mods[i], "mod.json");
 
 		// make sure mod.json exists, and is a file, otherwise, this
 		// is unlikely to be a mod folder

--- a/src/modules/packages.js
+++ b/src/modules/packages.js
@@ -183,17 +183,8 @@ packages.install = async (url, author, package_name, version) => {
 			// user, and make absolutely certain that they do want to
 			// install this package, as plugins have security concerns
 			let confirmation = await win.confirm(
-				`The following package has native plugins: ${name} \n\n`
-
-				+
-
-				"Native plugins have far more system access than a " +
-				"regular mod, and because of this they're inherently " +
-				"less secure to have installed, as a malicious plugin" +
-				" could do far more harm this way. If this plugin is " +
-				"one from a trusted developer or similar or you know " +
-				"what you're doing, then you can disregard this " +
-				"message completely."
+				`${lang("gui.mods.confirm_plugins_title")} ${name} \n\n` +
+				lang("gui.mods.confirm_plugins_description")
 			)
 
 			// check whether the user cancelled or confirmed the

--- a/src/modules/packages.js
+++ b/src/modules/packages.js
@@ -23,8 +23,12 @@ function update_path() {
 		} else {return}
 	} 
 
-	// create the folder, in case it doesn't already exist
-	fs.mkdirSync(packages.path);
+	// only create folder if the profile folder exists
+	if (fs.existsSync(path.dirname(packages.path))) {
+		// create the folder, in case it doesn't already exist
+		fs.mkdirSync(packages.path);
+	}
+
 }; update_path();
 
 packages.format_name = (author, package_name, version) => {

--- a/src/modules/packages.js
+++ b/src/modules/packages.js
@@ -268,7 +268,9 @@ packages.extract = async (zip_path, name) => {
 				path: extract_dir
 			}
 		)).on("finish", () => {
-			resolve(extract_dir);
+			setInterval(() => {
+				resolve(extract_dir);
+			}, 1000)
 		});
 	})
 }

--- a/src/modules/packages.js
+++ b/src/modules/packages.js
@@ -8,6 +8,8 @@ const json = require("./json");
 const win = require("./window");
 const settings = require("./settings");
 
+console = require("./console");
+
 var packages = {};
 
 function update_path() {
@@ -163,17 +165,17 @@ packages.install = async (url, author, package_name, version) => {
 
 	let name = packages.format_name(author, package_name, version);
 
-	console.log("Downloading package:", name);
+	console.info("Downloading package:", name);
 	// download `url` to a temporary dir, and return the path to it
 	let zip_path = await packages.download(url, name);
 
-	console.log("Extracting package:", name);
+	console.info("Extracting package:", name);
 	// extract the zip file we downloaded before, and return the path of
 	// the folder that we extracted it to
 	let package_path = await packages.extract(zip_path, name);
 
 
-	console.log("Verifying package:", name);
+	console.info("Verifying package:", name);
 	let verification = packages.verify(package_path);
 
 	switch(verification) {
@@ -190,22 +192,22 @@ packages.install = async (url, author, package_name, version) => {
 			// check whether the user cancelled or confirmed the
 			// installation, and act accordingly
 			if (! confirmation) {
-				return console.log("Cancelled package installation:", name);
+				return console.ok("Cancelled package installation:", name);
 			}
 			break;
 		default:
 			ipcMain.emit("failed-mod", name);
 
 			// other unhandled error
-			return console.log(
+			return console.error(
 				"Verification of package failed:", name,
 				", reason:", verification
 			);
 	}
 
-	console.log("Verified package:", name);
+	console.ok("Verified package:", name);
 
-	console.log("Deleting older version(s), if it exists:", name);
+	console.info("Deleting older version(s), if it exists:", name);
 	// check and delete any mod with the name package details in the old
 	// `mods` folder, if there are any at all
 	let mods = require("./mods");
@@ -222,12 +224,12 @@ packages.install = async (url, author, package_name, version) => {
 	// removes older version of package inside the `packages` folder
 	packages.remove(author, package_name, version);
 
-	console.log("Moving package:", name);
+	console.info("Moving package:", name);
 	let moved = packages.move(package_path);
 
 	if (! moved) {
 		ipcMain.emit("failed-mod", name);
-		console.log("Moving package failed:", name);
+		console.error("Moving package failed:", name);
 		return false;
 	}
 
@@ -236,7 +238,7 @@ packages.install = async (url, author, package_name, version) => {
 		fancy_name: package_name
 	})
 
-	console.log("Installed package:", name);
+	console.ok("Installed package:", name);
 	return true;
 }
 

--- a/src/modules/packages.js
+++ b/src/modules/packages.js
@@ -160,6 +160,7 @@ packages.install = async (url, author, package_name, version) => {
 	let verification = packages.verify(package_path);
 
 	switch(verification) {
+		case true: break;
 		case "has-plugins":
 			// if the package has plugins, then we want to prompt the
 			// user, and make absolutely certain that they do want to

--- a/src/modules/packages.js
+++ b/src/modules/packages.js
@@ -46,7 +46,7 @@ packages.split_name = (name) => {
 	}
 }
 
-packages.list = (dir = packages.path) => {
+packages.list = (dir = packages.path, no_functions) => {
 	let files = fs.readdirSync(dir);
 	let package_list = {};
 
@@ -93,13 +93,16 @@ packages.list = (dir = packages.path) => {
 					package_list[files[i]].has_mods = true;
 				}
 
-				// add `.remove()` function, mostly just a shorthand
-				package_list[files[i]].remove = () => {
-					return packages.remove(
-						split_name.author,
-						split_name.package_name,
-						split_name.version,
-					)
+				// add `.remove()` function, mostly just a shorthand,
+				// unless `no_functions` is `true`
+				if (! no_functions) {
+					package_list[files[i]].remove = () => {
+						return packages.remove(
+							split_name.author,
+							split_name.package_name,
+							split_name.version,
+						)
+					}
 				}
 
 				// set the `.icon` property

--- a/src/modules/packages.js
+++ b/src/modules/packages.js
@@ -209,16 +209,19 @@ packages.install = async (url, author, package_name, version) => {
 		}
 	}
 
+	// removes older version of package inside the `packages` folder
 	packages.remove(author, package_name, version);
 
 	console.log("Moving package:", name);
 	let moved = packages.move(package_path);
 
-	if (moved) {
-		console.log("Installed package:", name);
-	} else {
+	if (! moved) {
 		console.log("Moving package failed:", name);
+		return false;
 	}
+
+	console.log("Installed package:", name);
+	return true;
 }
 
 packages.download = async (url, name) => {


### PR DESCRIPTION
When finished this'll both add support for the new `packages/` folder discussed at [NorthstarLauncher #505](https://github.com/R2Northstar/NorthstarLauncher/issues/505) and simultaneously it'll also add support for installing plugins properly, discussed at [FlightCore #288](https://github.com/R2NorthstarTools/FlightCore/issues/288).

This PR is far from complete, and it's only currently here for the sake of tracking progress.

#### TODO


 - [x] Basic management of packages
   - [x] Enabling/Disabling packages
   - [x] Detect and install dependencies
   - [x] Remove older versions if they exist, i.e updating
   - [x] Move packages in `mods/` to `packages/` when updating
   - [x] Downloading, extracting, verifying and installing a package from a URL
   - [x] Present warning/confirmation dialog when installing a package with plugins
 - [x] Implement everything in the frontend
   - [x] Toggling packages
   - [x] Removing packages
   - [x] Showing packages in the mod list
   - [x] Installing of packages through mod browser
   - [x] Updating of packages through mod list and mod browser
 - [x] Localizations
   - [x] German - @DxsSucuk
   - [x] French - @Alystrasz
   - [x] Spanish - @AA-Delta

Strings that need to be localized:
```json
"gui.mods.confirm_plugins_title": "The following package has native plugins:",
"gui.mods.confirm_plugins_description": "Native plugins have far more system access than a regular mod, and because of this they're inherently less secure to have installed, as a malicious plugin could do far more harm this way. If this plugin is one from a trusted developer or similar or you know what you're doing, then you can disregard this message completely.",
```