### PR TITLE
Fixed formatting issue in the up-to-date console message.

### DIFF
--- a/src/modules/update.js
+++ b/src/modules/update.js
@@ -172,7 +172,7 @@ update.northstar = async () => {
 	// Makes sure it is not already the latest version
 	if (! await northstar_update_available()) {
 		ipcMain.emit("ns-update-event", "cli.update.uptodate.short");
-		console.ok(lang("cli.update.uptodate"), ns_version);
+		console.ok(lang("cli.update.uptodate").replace("%s", ns_version));
 
 		win.log(lang("gui.update.uptodate"));
 		cli.exit();


### PR DESCRIPTION
The up-to-date message in the console has a formatting issue: The string specifier is not correctly substituted and can therefore still be seen.
The version also gets appended to the string.