### PR TITLE
i18n: Add missing localization strings

### DIFF
--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -172,6 +172,32 @@
 			"originkill": {
 				"title": "Automatisch Origin und oder EA Desktop schließen",
 				"desc": "Wenn Viper sich schließt soll Origin und oder EA Desktop sich auch schließen."
+			},
+
+			"updatebuttons": {
+				"title": "",
+				"desc": "",
+				"buttons": {
+					"reset_cached_api_requests": "",
+					"force_northstar_reinstall": "",
+					"force_delete_install_cache": ""
+				}
+			},
+
+			"miscbuttons": {
+				"title": "",
+				"desc": "",
+				"buttons": {
+					"open_gamepath": "",
+					"reset_config": "",
+					"restart_viper": "",
+					"change_gamepath": "",
+					"force_quit_game": "",
+					"force_quit_origin": ""
+				},
+
+				"open_gamepath_alert": "",
+				"reset_config_alert": ""
 			}
 		},
 
@@ -195,7 +221,10 @@
 		"gamepath": {
 			"must": "Der Installationspfad muss gesetzt worden sein um Viper zu nutzen.",
 			"wrong": "Der angegebene Installationspfad ist nicht gültig!",
-			"lost": "Der angegeben Installationspfad ist nicht mehr gültig!\n\nBitte stelle sicher das die Festplatte mounted ist, oder falls sich der Installationspfad geändert hat, das du diesen auch in Viper aktualisierst!\n\nViper wird möglicherweiße bis zum nächsten Neustart nicht funktionieren!"
+			"lost": "Der angegeben Installationspfad ist nicht mehr gültig!\n\nBitte stelle sicher das die Festplatte mounted ist, oder falls sich der Installationspfad geändert hat, das du diesen auch in Viper aktualisierst!\n\nViper wird möglicherweiße bis zum nächsten Neustart nicht funktionieren!",
+			"lost_perms": "",
+			"found_missing_perms": "",
+			"missing_perms": ""
 		},
 
 		"toast": {
@@ -238,7 +267,8 @@
 		"menu": {
 			"main": "Northstar Launcher",
 			"mods": "Mods",
-			"release": "Release Notes"
+			"release": "Release Notes",
+			"force_quit": ""
 		}
 	},
 

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -175,29 +175,29 @@
 			},
 
 			"updatebuttons": {
-				"title": "",
-				"desc": "",
+				"title": "Reparations Aktionen",
+				"desc": "Bei Problemen mit updates könnte diese Aktionen helfen.",
 				"buttons": {
-					"reset_cached_api_requests": "",
-					"force_northstar_reinstall": "",
-					"force_delete_install_cache": ""
+					"reset_cached_api_requests": "API zwischenspeicher leerung erzwingen",
+					"force_northstar_reinstall": "Northstar neuinstallation erzwingen",
+					"force_delete_install_cache": "Zwischengespeicherte Installationsdateien löschung erzwingen"
 				}
 			},
 
 			"miscbuttons": {
-				"title": "",
-				"desc": "",
+				"title": "Zusatz Aktionen",
+				"desc": "Beim weiteren Problemen könnten diesen Aktion helfen.",
 				"buttons": {
-					"open_gamepath": "",
-					"reset_config": "",
-					"restart_viper": "",
-					"change_gamepath": "",
-					"force_quit_game": "",
-					"force_quit_origin": ""
+					"open_gamepath": "Spielepfad öffnen",
+					"reset_config": "Konfiguration zurücksetzung erzwingen",
+					"restart_viper": "Viper neustarten",
+					"change_gamepath": "Spielepfad ändern",
+					"force_quit_game": "Titanfall/Northstar schließung erzwingen",
+					"force_quit_origin": "Origin/EA Desktop schließung erzwingen"
 				},
 
-				"open_gamepath_alert": "",
-				"reset_config_alert": ""
+				"open_gamepath_alert": "Fehlerhafter Spielepfad, dadurch kann keiner geöffnet werden. Bitte wähle den richtigen Pfad zuerst!",
+				"reset_config_alert": "Bestätige die Zurücksetzung der Konfiguration, Viper wird nach dem bestätigen die Konfiguration Datein löschen und neustarten."
 			}
 		},
 
@@ -222,9 +222,9 @@
 			"must": "Der Installationspfad muss gesetzt worden sein um Viper zu nutzen.",
 			"wrong": "Der angegebene Installationspfad ist nicht gültig!",
 			"lost": "Der angegeben Installationspfad ist nicht mehr gültig!\n\nBitte stelle sicher das die Festplatte mounted ist, oder falls sich der Installationspfad geändert hat, das du diesen auch in Viper aktualisierst!\n\nViper wird möglicherweiße bis zum nächsten Neustart nicht funktionieren!",
-			"lost_perms": "",
-			"found_missing_perms": "",
-			"missing_perms": ""
+			"lost_perms": "Wie es aussieht hat der jetzige Nutzer die Rechte Datein zulesen oder zuschreiben im Spielepfad verloren, bitte wähle einen richtigen Pfad aus oder erhalte die benötigten Berechtigungen für den jetzigen:\n\n",
+			"found_missing_perms": "Es wurde ein Spielepfad automatisch gefunden, jedoch fehlen dir die Rechte Datein zulesen oder zuschreiben in diesem Pfad. Bitte wähle einen anderen Pfad aus oder erhalte die benötigten Berechtigungen für den gewählten Pfad:\n\n",
+			"missing_perms": "Wie es aussieht hat der jetzige Nutzer die Rechte Datein zulesen oder zuschreiben im Spielepfad nicht, bitte wähle einen richtigen Pfad aus oder erhalte die benötigten Berechtigungen für den gewählten Pfad:\n\n"
 		},
 
 		"toast": {
@@ -268,7 +268,7 @@
 			"main": "Northstar Launcher",
 			"mods": "Mods",
 			"release": "Release Notes",
-			"force_quit": ""
+			"force_quit": "Schließen erzwingen"
 		}
 	},
 

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -175,29 +175,29 @@
 			},
 
 			"updatebuttons": {
-				"title": "",
-				"desc": "",
+				"title": "Opciones de reparación",
+				"desc": "Si estás teniendo problemas con las actualizaciones, algunos de estos botones pueden ayudar a solucionarlos.",
 				"buttons": {
-					"reset_cached_api_requests": "",
-					"force_northstar_reinstall": "",
-					"force_delete_install_cache": ""
+					"reset_cached_api_requests": "Restablecer las solicitudes de API en caché",
+					"force_northstar_reinstall": "Forzar la reinstalación de Northstar",
+					"force_delete_install_cache": "Forzar la eliminación de archivos de instalación en caché"
 				}
 			},
 
 			"miscbuttons": {
-				"title": "",
-				"desc": "",
+				"title": "Acciones de reparación diversas",
+				"desc": "Si estás teniendo problemas, entonces algunos de estos botones pueden ayudar a solucionarlo",
 				"buttons": {
-					"open_gamepath": "",
-					"reset_config": "",
-					"restart_viper": "",
-					"change_gamepath": "",
-					"force_quit_game": "",
-					"force_quit_origin": ""
+					"open_gamepath": "Abrir ruta del juego",
+					"reset_config": "Restablecer archivo de configuración",
+					"restart_viper": "Reiniciar Viper",
+					"change_gamepath": "Cambiar ruta del juego",
+					"force_quit_game": "Cerrar forzosamente Titanfall y Northstar",
+					"force_quit_origin": "Cerrar forzosamente Origin y/o EA Desktop"
 				},
 
-				"open_gamepath_alert": "",
-				"reset_config_alert": ""
+				"open_gamepath_alert": "No se ha seleccionado una ruta de juego válida, por lo que no hay una ruta de juego para abrir. ¡Por favor, selecciona primero una ruta de juego válida!",
+				"reset_config_alert": "Por favor, confirma que deseas restablecer el archivo de configuración. Después de confirmar, Viper eliminará el archivo de configuración y luego reiniciará."
 			}
 		},
 
@@ -222,9 +222,9 @@
 			"must": "La ruta del juego debe establecerse para ejecutar Viper.",
 			"wrong": "Esta carpeta no es una ruta válida para el juego.",
 			"lost": "¡El directorio del juego ya no existe/no se puede encontrar!\n\nAsegúrate de que tu unidad esté instalada correctamente o, si cambiaste la ubicación del juego, actualiza la ruta del juego.\n\nViper puede no funcionar correctamente hasta el próximo reinicio!",
-			"lost_perms": "",
-			"found_missing_perms": "",
-			"missing_perms": ""
+			"lost_perms": "Tu usuario parece haber perdido permisos para crear o leer archivos en la ruta de juego seleccionada. Por favor, selecciona una ruta de juego válida o recupera el acceso para leer y escribir en la carpeta:\n\n",
+			"found_missing_perms": "Se encontró automáticamente una ruta de juego válida, pero tu usuario no tiene permisos para crear o leer archivos en ella. Por favor, selecciona manualmente una ruta de juego diferente o obtén acceso para leer y escribir en la carpeta:\n\n",
+			"missing_perms": "Tu usuario no tiene permisos para crear o leer archivos en la ruta de juego seleccionada. Por favor, selecciona una ruta de juego diferente o obtén acceso para leer y escribir en la carpeta:\n\n"
 		},
 
 		"toast": {
@@ -268,7 +268,7 @@
 			"main": "Northstar Launcher",
 			"mods": "Modificaciones",
 			"release": "Notas de actualización",
-			"force_quit": ""
+			"force_quit": "Cerrar forzosamente el juego"
 		}
 	},
 

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -172,6 +172,32 @@
 			"originkill": {
 				"title": "Cerrar Origin o la aplicación de EA automáticamente",
 				"desc": "Cuando Viper se cierra, cerrar junto a Origin o la aplicación de EA"
+			},
+
+			"updatebuttons": {
+				"title": "",
+				"desc": "",
+				"buttons": {
+					"reset_cached_api_requests": "",
+					"force_northstar_reinstall": "",
+					"force_delete_install_cache": ""
+				}
+			},
+
+			"miscbuttons": {
+				"title": "",
+				"desc": "",
+				"buttons": {
+					"open_gamepath": "",
+					"reset_config": "",
+					"restart_viper": "",
+					"change_gamepath": "",
+					"force_quit_game": "",
+					"force_quit_origin": ""
+				},
+
+				"open_gamepath_alert": "",
+				"reset_config_alert": ""
 			}
 		},
 
@@ -195,7 +221,10 @@
 		"gamepath": {
 			"must": "La ruta del juego debe establecerse para ejecutar Viper.",
 			"wrong": "Esta carpeta no es una ruta válida para el juego.",
-			"lost": "¡El directorio del juego ya no existe/no se puede encontrar!\n\nAsegúrate de que tu unidad esté instalada correctamente o, si cambiaste la ubicación del juego, actualiza la ruta del juego.\n\nViper puede no funcionar correctamente hasta el próximo reinicio!"
+			"lost": "¡El directorio del juego ya no existe/no se puede encontrar!\n\nAsegúrate de que tu unidad esté instalada correctamente o, si cambiaste la ubicación del juego, actualiza la ruta del juego.\n\nViper puede no funcionar correctamente hasta el próximo reinicio!",
+			"lost_perms": "",
+			"found_missing_perms": "",
+			"missing_perms": ""
 		},
 
 		"toast": {
@@ -238,7 +267,8 @@
 		"menu": {
 			"main": "Northstar Launcher",
 			"mods": "Modificaciones",
-			"release": "Notas de actualización"
+			"release": "Notas de actualización",
+			"force_quit": ""
 		}
 	},
 

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -172,6 +172,32 @@
 			"originkill": {
 				"title": "Quitter automatiquement Origin et/ou EA app",
 				"desc": "Lorsque Viper est fermé, Origin et/ou EA app sera également automatiquement fermé."
+			},
+
+			"updatebuttons": {
+				"title": "",
+				"desc": "",
+				"buttons": {
+					"reset_cached_api_requests": "",
+					"force_northstar_reinstall": "",
+					"force_delete_install_cache": ""
+				}
+			},
+
+			"miscbuttons": {
+				"title": "",
+				"desc": "",
+				"buttons": {
+					"open_gamepath": "",
+					"reset_config": "",
+					"restart_viper": "",
+					"change_gamepath": "",
+					"force_quit_game": "",
+					"force_quit_origin": ""
+				},
+
+				"open_gamepath_alert": "",
+				"reset_config_alert": ""
 			}
 		},
 
@@ -195,7 +221,10 @@
 		"gamepath": {
 			"must": "Vous devez sélectionner le chemin du dossier du jeu Titanfall 2 pour pouvoir lancer Viper.",
 			"wrong": "Ce dossier ne contient pas le jeu Titanfall 2, et n'est donc pas valide.",
-			"lost": "Le chemin du jeu ne peut être trouvé / n'existe plus !\n\nVeuillez vérifier que votre disqué est correctement monté, ou, si vous avez déplacé votre jeu, que vous avez mis à jour le chemin du dossier.\n\nViper ne fonctionnera pas correctement jusqu'au prochain redémarrage."
+			"lost": "Le chemin du jeu ne peut être trouvé / n'existe plus !\n\nVeuillez vérifier que votre disqué est correctement monté, ou, si vous avez déplacé votre jeu, que vous avez mis à jour le chemin du dossier.\n\nViper ne fonctionnera pas correctement jusqu'au prochain redémarrage.",
+			"lost_perms": "",
+			"found_missing_perms": "",
+			"missing_perms": ""
 		},
 
 		"toast": {
@@ -238,7 +267,8 @@
 		"menu": {
 			"main": "Lanceur Northstar",
 			"mods": "Mods",
-			"release": "Notes de mises à jour"
+			"release": "Notes de mises à jour",
+			"force_quit": ""
 		}
 	},
 


### PR DESCRIPTION
Due to the change in the formatting of localization files, or well, possible formatting, the old formatting is still allowed, but I digress, it'll be easier for everybody to simply make a comment here with the translated strings, and I'll paste them in not long after.

 - [x] German - @DxsSucuk
 - [x] French - @Alystrasz
 - [x] Spanish - @XNovaDelta

Strings to localize:
```json
"gui.settings.updatebuttons.title": "Repair actions",
"gui.settings.updatebuttons.desc": "If you're having problems with updates, some of these buttons may help in fixing them.",
"gui.settings.updatebuttons.buttons.reset_cached_api_requests": "Reset cached API requests",
"gui.settings.updatebuttons.buttons.force_northstar_reinstall": "Force re-install of Northstar",
"gui.settings.updatebuttons.buttons.force_delete_install_cache": "Force delete cached install files",
"gui.settings.miscbuttons.title": "Misc repair actions",
"gui.settings.miscbuttons.desc": "If you're having problems then some of these buttons may help fixing it",
"gui.settings.miscbuttons.buttons.open_gamepath": "Open gamepath",
"gui.settings.miscbuttons.buttons.reset_config": "Reset config file",
"gui.settings.miscbuttons.buttons.restart_viper": "Restart Viper",
"gui.settings.miscbuttons.buttons.change_gamepath": "Change gamepath",
"gui.settings.miscbuttons.buttons.force_quit_game": "Force quit Titanfall and Northstar",
"gui.settings.miscbuttons.buttons.force_quit_origin": "Force quit Origin and or EA Desktop",
"gui.settings.miscbuttons.open_gamepath_alert": "No valid gamepath is selected, so there's no gamepath to open, please select a valid gamepath first!",
"gui.settings.miscbuttons.reset_config_alert": "Please confirm that you want to reset the config file, after confirming Viper will delete the config file, and then restart.",
"gui.gamepath.lost_perms": "Your user seems to have lost permissions to create and or read files in the selected gamepath, please select a gamepath or gain access to read and write to the folder:\n\n",
"gui.gamepath.found_missing_perms": "Automatically found a valid gamepath, however your user doesn't have permissions to create and or read files in it, please manually select a different gamepath or gain access to read and write to the folder:\n\n",
"gui.gamepath.missing_perms": "Your user doesn't have permissions to create and or read files in the selected gamepath, please select a different gamepath or gain access to read and write to the folder:\n\n",
"ns.menu.force_quit": "Force quit game"
```
